### PR TITLE
refactor: renames eth -> rbtc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Live on Rinkeby](https://img.shields.io/badge/wallet-Live%20on%20Rinkeby-blue)](https://rinkeby.zksync.io)
 [![Live on Ropsten](https://img.shields.io/badge/wallet-Live%20on%20Ropsten-blue)](https://ropsten.zksync.io)
 
-zkSync is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of ETH
+zkSync is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of RBTC
 and ERC20 tokens in the Rootstock network.
 
 ## Description

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,7 +1,7 @@
 # zkSync Smart Contracts
 
 **zkSync** is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of
-ETH and ERC20 tokens in the Rootstock network.
+RBTC and ERC20 tokens in the Rootstock network.
 
 This document is a description of the zkSync smart contracts.
 

--- a/contracts/contracts/Config.sol
+++ b/contracts/contracts/Config.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.7.0;
 /// @title zkSync configuration constants
 /// @author Matter Labs
 contract Config {
-    /// @dev ERC20 tokens and ETH withdrawals gas limit, used only for complete withdrawals
+    /// @dev ERC20 tokens and RBTC withdrawals gas limit, used only for complete withdrawals
     uint256 internal constant WITHDRAWAL_GAS_LIMIT = 100000;
 
     /// @dev NFT withdrawals gas limit, used only for complete withdrawals
@@ -28,7 +28,7 @@ contract Config {
     /// @dev Success flag bytes length
     uint8 internal constant SUCCESS_FLAG_BYTES = 1;
 
-    /// @dev Max amount of tokens registered in the network (excluding ETH, which is hardcoded as tokenId = 0)
+    /// @dev Max amount of tokens registered in the network (excluding RBTC, which is hardcoded as tokenId = 0)
     uint32 internal constant MAX_AMOUNT_OF_REGISTERED_TOKENS = $(MAX_AMOUNT_OF_REGISTERED_TOKENS);
 
     /// @dev Max account id that could be registered in the network

--- a/contracts/contracts/ForcedExit.sol
+++ b/contracts/contracts/ForcedExit.sol
@@ -39,7 +39,7 @@ contract ForcedExit is Ownable, ReentrancyGuard {
         uint256 balance = address(this).balance;
 
         (bool success, ) = _to.call{value: balance}("");
-        require(success, "ETH withdraw failed");
+        require(success, "RBTC withdraw failed");
     }
 
     // We have to use fallback instead of `receive` since the ethabi

--- a/contracts/contracts/Governance.sol
+++ b/contracts/contracts/Governance.sol
@@ -37,7 +37,7 @@ contract Governance is Config {
     /// @notice Address which will exercise governance over the network i.e. add tokens, change validator set, conduct upgrades
     address public networkGovernor;
 
-    /// @notice Total number of ERC20 tokens registered in the network (excluding ETH, which is hardcoded as tokenId = 0)
+    /// @notice Total number of ERC20 tokens registered in the network (excluding RBTC, which is hardcoded as tokenId = 0)
     uint16 public totalTokens;
 
     /// @notice List of registered tokens by tokenId
@@ -103,7 +103,7 @@ contract Governance is Config {
         require(totalTokens < MAX_AMOUNT_OF_REGISTERED_TOKENS, "1f"); // no free identifiers for tokens
 
         totalTokens++;
-        uint16 newTokenId = totalTokens; // it is not `totalTokens - 1` because tokenId = 0 is reserved for eth
+        uint16 newTokenId = totalTokens; // it is not `totalTokens - 1` because tokenId = 0 is reserved for rbtc
 
         tokenAddresses[newTokenId] = _token;
         tokenIds[_token] = newTokenId;

--- a/contracts/contracts/ZkSync.sol
+++ b/contracts/contracts/ZkSync.sol
@@ -206,9 +206,9 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
         delegateAdditional();
     }
 
-    /// @notice Deposit ETH to Layer 2 - transfer ether from user into contract, validate it, register deposit
+    /// @notice Deposit RBTC to Layer 2 - transfer ether from user into contract, validate it, register deposit
     /// @param _zkSyncAddress The receiver Layer 2 address
-    function depositETH(address _zkSyncAddress) external payable {
+    function depositRBTC(address _zkSyncAddress) external payable {
         require(_zkSyncAddress != SPECIAL_ACCOUNT_ADDRESS, "P");
         require(msg.value > 0, "M"); // Zero-value deposits are forbidden by zkSync rollup logic
         requireActive();
@@ -242,7 +242,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
 
     /// @notice Returns amount of tokens that can be withdrawn by `address` from zkSync contract
     /// @param _address Address of the tokens owner
-    /// @param _token Address of token, zero address is used for ETH
+    /// @param _token Address of token, zero address is used for RBTC
     function getPendingBalance(address _address, address _token) public view returns (uint128) {
         uint16 tokenId = 0;
         if (_token != address(0)) {
@@ -253,7 +253,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
 
     /// @notice  Withdraws tokens from zkSync contract to the owner
     /// @param _owner Address of the tokens owner
-    /// @param _token Address of tokens, zero address is used for ETH
+    /// @param _token Address of tokens, zero address is used for RBTC
     /// @param _amount Amount to withdraw to request.
     ///         NOTE: We will call ERC20.transfer(.., _amount), but if according to internal logic of ERC20 token zkSync contract
     ///         balance will be decreased by value more then _amount we will try to subtract this value from user pending balance
@@ -274,7 +274,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
 
         if (tokenId == 0) {
             (bool success, ) = _owner.call{value: amount}("");
-            require(success, "d"); // ETH withdraw failed
+            require(success, "d"); // RBTC withdraw failed
         } else {
             // We will allow withdrawals of `value` such that:
             // `value` <= user pending balance
@@ -498,7 +498,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
         emit WithdrawalPending(_tokenId, _recipient, _amount);
     }
 
-    /// @dev helper function to process ETH/ERC20 withdrawal
+    /// @dev helper function to process RBTC/ERC20 withdrawal
     function handleWithdrawFT(
         bool _completeWithdrawals,
         uint16 _tokenId,
@@ -1010,7 +1010,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
         pendingBalances[_packedBalanceKey] = PendingBalance(balance.add(_amount), FILLED_GAS_RESERVE_VALUE);
     }
 
-    /// @notice Sends ETH
+    /// @notice Sends RBTC
     /// @param _to Address of recipient
     /// @param _amount Amount of tokens to transfer
     /// @return bool flag indicating that transfer is successful

--- a/contracts/src.ts/deploy.ts
+++ b/contracts/src.ts/deploy.ts
@@ -144,7 +144,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_CREATE2_FACTORY_ADDR=${create2Factory.address}`);
             console.log(
-                `Create2 factory deployed, gasUsed: ${gasUsed.toString()}, eth spent: ${formatEther(
+                `Create2 factory deployed, gasUsed: ${gasUsed.toString()}, rbtc spent: ${formatEther(
                     gasUsed.mul(gasPrice)
                 )}`
             );
@@ -177,7 +177,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_GOVERNANCE_TARGET_ADDR=${address}`);
             console.log(
-                `Governance target deployed, gasUsed: ${govGasUsed.toString()}, eth spent: ${formatEther(
+                `Governance target deployed, gasUsed: ${govGasUsed.toString()}, rbtc spent: ${formatEther(
                     govGasUsed.mul(gasPrice)
                 )}`
             );
@@ -203,7 +203,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_VERIFIER_TARGET_ADDR=${address}`);
             console.log(
-                `Verifier target deployed, gasUsed: ${verGasUsed.toString()}, eth spent: ${formatEther(
+                `Verifier target deployed, gasUsed: ${verGasUsed.toString()}, rbtc spent: ${formatEther(
                     verGasUsed.mul(gasPrice)
                 )}`
             );
@@ -229,7 +229,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_CONTRACT_TARGET_ADDR=${address}`);
             console.log(
-                `zkSync target deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `zkSync target deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );
@@ -287,7 +287,7 @@ export class Deployer {
             console.log(`CONTRACTS_UPGRADE_GATEKEEPER_ADDR=${this.addresses.UpgradeGatekeeper}`);
             console.log(`CONTRACTS_GENESIS_TX_HASH=${txHash}`);
             console.log(
-                `Deploy finished, gasUsed: ${gasUsed.toString()}, eth spent: ${formatEther(gasUsed.mul(gasPrice))}`
+                `Deploy finished, gasUsed: ${gasUsed.toString()}, rbtc spent: ${formatEther(gasUsed.mul(gasPrice))}`
             );
         }
     }
@@ -317,7 +317,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_NFT_FACTORY_ADDR=${nftFactoryContarct.address}`);
             console.log(
-                `NFT Factory contract deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `NFT Factory contract deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );
@@ -355,7 +355,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`\nCONTRACTS_LISTING_GOVERNANCE=${tokenGovernanceContract.address}\n`);
             console.log(
-                `Token governance contract deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `Token governance contract deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );
@@ -391,7 +391,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_FORCED_EXIT_ADDR=${forcedExitContract.address}`);
             console.log(
-                `ForcedExit contract deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `ForcedExit contract deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );
@@ -417,7 +417,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`CONTRACTS_ADDITIONAL_ZKSYNC_ADDR=${address}`);
             console.log(
-                `Additiinal zkSync contract deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `Additiinal zkSync contract deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );
@@ -448,7 +448,7 @@ export class Deployer {
         if (this.verbose) {
             console.log(`MISC_REGENESIS_MULTISIG_ADDRESS=${regenesisMultisigContract.address}`);
             console.log(
-                `Regenesis Multisig contract deployed, gasUsed: ${zksGasUsed.toString()}, eth spent: ${formatEther(
+                `Regenesis Multisig contract deployed, gasUsed: ${zksGasUsed.toString()}, rbtc spent: ${formatEther(
                     zksGasUsed.mul(gasPrice)
                 )}`
             );

--- a/contracts/test/zksync.spec.ts
+++ b/contracts/test/zksync.spec.ts
@@ -192,7 +192,7 @@ describe('ZK priority queue ops unit tests', function () {
 
         let tx;
         if (token === hardhat.ethers.constants.AddressZero) {
-            tx = await zksyncContract.depositETH(depositOwner, {
+            tx = await zksyncContract.depositRBTC(depositOwner, {
                 value: depositAmount
             });
         } else {
@@ -243,7 +243,7 @@ describe('ZK priority queue ops unit tests', function () {
         expect(priorityQueueEvent.args.expirationBlock, 'expiration block').eq(deadlineBlock);
     }
 
-    it('success ETH deposits', async () => {
+    it('success RBTC deposits', async () => {
         zksyncContract.connect(wallet);
         const tokenAddress = hardhat.ethers.constants.AddressZero;
         const depositAmount = parseEther('1.0');
@@ -370,7 +370,7 @@ describe('zkSync withdraw unit tests', function () {
         );
     }
 
-    it('Withdraw ETH success', async () => {
+    it('Withdraw RBTC success', async () => {
         zksyncContract.connect(wallet);
         const withdrawAmount = parseEther('1.0');
 
@@ -389,7 +389,7 @@ describe('zkSync withdraw unit tests', function () {
         await performWithdraw(wallet, constants.AddressZero, 0, withdrawAmount.div(2));
     });
 
-    it('Withdraw ETH incorrect amount', async () => {
+    it('Withdraw RBTC incorrect amount', async () => {
         zksyncContract.connect(wallet);
         const withdrawAmount = parseEther('1.0');
 
@@ -647,7 +647,7 @@ describe('zkSync test process next operation', function () {
         zksyncContract.connect(wallet);
         const depositAmount = BigNumber.from('2');
 
-        await zksyncContract.depositETH(wallet.address, { value: depositAmount });
+        await zksyncContract.depositRBTC(wallet.address, { value: depositAmount });
 
         // construct deposit pubdata
         const pubdata = Buffer.alloc(CHUNK_SIZE * 6, 0);

--- a/core/README.md
+++ b/core/README.md
@@ -1,7 +1,7 @@
 # zkSync Core Backend
 
 **zkSync** is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of
-ETH and ERC20 tokens in the Rootstock network.
+RBTC and ERC20 tokens in the Rootstock network.
 
 This document is a description of the core components of the project.
 

--- a/core/bin/zksync_api/src/api_server/helpers.rs
+++ b/core/bin/zksync_api/src/api_server/helpers.rs
@@ -38,7 +38,7 @@ async fn depositing_from_pending_ops(
 
     for op in pending_ops {
         let token_symbol = if *op.token_id == 0 {
-            "ETH".to_string()
+            "RBTC".to_string()
         } else {
             tokens
                 .get_token(storage, op.token_id)

--- a/core/bin/zksync_api/src/api_server/rest/v01/api_impl.rs
+++ b/core/bin/zksync_api/src/api_server/rest/v01/api_impl.rs
@@ -72,13 +72,13 @@ impl ApiV01 {
             .await
             .map_err(Self::db_error)?;
 
-        // Add ETH for tokens allowed for fee
-        // Different APIs have different views on how to represent ETH in their system.
-        // But ETH is always allowed to pay fee, and in all cases it should be on the list.
+        // Add RBTC for tokens allowed for fee
+        // Different APIs have different views on how to represent RBTC in their system.
+        // But RBTC is always allowed to pay fee, and in all cases it should be on the list.
 
         if tokens.get(&TokenId(0)).is_none() {
-            let eth = Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20);
-            tokens.insert(eth.id, eth);
+            let rbtc = Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20);
+            tokens.insert(rbtc.id, rbtc);
         }
 
         let mut tokens = tokens.values().cloned().collect::<Vec<_>>();

--- a/core/bin/zksync_api/src/api_server/rest/v02/account.rs
+++ b/core/bin/zksync_api/src/api_server/rest/v02/account.rs
@@ -663,7 +663,7 @@ mod tests {
                 .await?;
         }
         let balances = vec![(
-            String::from("ETH"),
+            String::from("RBTC"),
             DepositingFunds {
                 amount: BigUint::from(301500u32),
                 expected_accept_block: 25 + server.confirmations_for_eth_event,

--- a/core/bin/zksync_api/src/api_server/rest/v02/test_utils.rs
+++ b/core/bin/zksync_api/src/api_server/rest/v02/test_utils.rs
@@ -186,7 +186,7 @@ impl TestServerConfig {
             let tx = from
                 .sign_transfer(
                     TokenId(0),
-                    "ETH",
+                    "RBTC",
                     closest_packable_token_amount(&10_u64.into()),
                     closest_packable_fee_amount(&fee.into()),
                     &to.address,
@@ -294,7 +294,7 @@ impl TestServerConfig {
             let tx = from
                 .sign_mint_nft(
                     TokenId(0),
-                    "ETH",
+                    "RBTC",
                     H256::random(),
                     closest_packable_fee_amount(&fee.into()),
                     &to.address,

--- a/core/bin/zksync_api/src/api_server/rest/v02/transaction.rs
+++ b/core/bin/zksync_api/src/api_server/rest/v02/transaction.rs
@@ -320,7 +320,7 @@ mod tests {
         let mut tokens = HashMap::new();
         tokens.insert(
             TokenLike::Id(TokenId(0)),
-            Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20),
+            Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20),
         );
         let mut market = HashMap::new();
         market.insert(
@@ -366,7 +366,7 @@ mod tests {
         assert_eq!(tx.hash(), tx_hash);
 
         let TestTransactions { acc, txs } = TestServerConfig::gen_zk_txs(1_00);
-        let eth = Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20);
+        let rbtc = Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20);
         let (good_batch, expected_tx_hashes): (Vec<_>, Vec<_>) = txs
             .into_iter()
             .map(|(tx, _op)| {
@@ -391,7 +391,7 @@ mod tests {
 
         let txs = good_batch
             .iter()
-            .zip(std::iter::repeat(eth))
+            .zip(std::iter::repeat(rbtc))
             .map(|(tx, token)| (tx.tx.clone(), token, tx.tx.account()))
             .collect::<Vec<_>>();
         let batch_signature = {

--- a/core/bin/zksync_api/src/api_server/rpc_server/rpc_impl.rs
+++ b/core/bin/zksync_api/src/api_server/rpc_server/rpc_impl.rs
@@ -261,7 +261,7 @@ impl RpcApp {
             .drain()
             .map(|(id, token)| {
                 if *id == 0 {
-                    ("ETH".to_string(), token)
+                    ("RBTC".to_string(), token)
                 } else {
                     (token.symbol.clone(), token)
                 }

--- a/core/bin/zksync_api/src/api_server/rpc_server/rpc_trait.rs
+++ b/core/bin/zksync_api/src/api_server/rpc_server/rpc_trait.rs
@@ -62,7 +62,7 @@ pub trait Rpc {
     #[rpc(name = "contract_address", returns = "ContractAddressResp")]
     fn contract_address(&self) -> BoxFutureResult<ContractAddressResp>;
 
-    /// "ETH" | #ERC20_ADDRESS => {Token}
+    /// "RBTC" | #ERC20_ADDRESS => {Token}
     #[rpc(name = "tokens", returns = "Token")]
     fn tokens(&self) -> BoxFutureResult<HashMap<String, Token>>;
 

--- a/core/bin/zksync_api/src/bin/dev-liquidity-token-watcher.rs
+++ b/core/bin/zksync_api/src/bin/dev-liquidity-token-watcher.rs
@@ -111,7 +111,7 @@ async fn handle_graphql(
         data: GraphqlTokenResponse {
             token: Some(TokenResponse {
                 total_liquidity: volume.to_string(),
-                derived_eth: "1.0".to_string(),
+                derived_rbtc: "1.0".to_string(),
             }),
         },
     };

--- a/core/bin/zksync_api/src/bin/dev-ticker-server.rs
+++ b/core/bin/zksync_api/src/bin/dev-ticker-server.rs
@@ -56,7 +56,7 @@ async fn handle_coinmarketcap_token_price_query(
 ) -> Result<HttpResponse> {
     let symbol = query.symbol.clone();
     let base_price = match symbol.as_str() {
-        "ETH" => BigDecimal::from(200),
+        "RBTC" => BigDecimal::from(1800),
         "wBTC" => BigDecimal::from(9000),
         "BAT" => BigDecimal::try_from(0.2).unwrap(),
         // Even though these tokens have their base price equal to
@@ -65,7 +65,7 @@ async fn handle_coinmarketcap_token_price_query(
         "DAI" => BigDecimal::from(1),
         "tGLM" => BigDecimal::from(1),
         "GLM" => BigDecimal::from(1),
-        "RBTC" => BigDecimal::from(18000),
+
         "RIF" => BigDecimal::try_from(0.053533).unwrap(),
         _ => BigDecimal::from(1),
     };
@@ -118,10 +118,9 @@ fn load_tokens(path: impl AsRef<Path>) -> Vec<TokenData> {
                 let mut platforms = HashMap::new();
                 platforms.insert(String::from("rootstock"), token.address);
                 let id = match symbol.as_str() {
-                    "eth" => String::from("rootstock"),
+                    "rbtc" => String::from("rootstock"),
                     "wbtc" => String::from("wrapped-bitcoin"),
                     "bat" => String::from("basic-attention-token"),
-                    "RBTC" => String::from("RSK-smart-bitcoin"),
                     "RIF" => String::from("RSK-infrastructure-framework"),
                     _ => symbol.clone(),
                 };

--- a/core/bin/zksync_api/src/fee_ticker/tests.rs
+++ b/core/bin/zksync_api/src/fee_ticker/tests.rs
@@ -60,7 +60,7 @@ impl TestToken {
             .unwrap_or_else(|| Ratio::from_integer(1u32.into()))
     }
 
-    fn eth() -> Self {
+    fn rbtc() -> Self {
         Self::new(TokenId(0), 182.0, None, 18, Address::default())
     }
 
@@ -88,7 +88,7 @@ impl TestToken {
 
     pub(crate) fn all_tokens() -> Vec<Self> {
         vec![
-            Self::eth(),
+            Self::rbtc(),
             Self::cheap(),
             Self::expensive(),
             Self::hex(),
@@ -175,7 +175,7 @@ impl FeeTickerInfo for MockTickerInfo {
         unreachable!("incorrect token input")
     }
 
-    /// Get current gas price in ETH
+    /// Get current gas price in RBTC
     async fn get_gas_price_wei(&self) -> Result<BigUint, anyhow::Error> {
         Ok(BigUint::from(10u32).pow(7u32)) // 10 GWei
     }
@@ -464,7 +464,7 @@ fn test_ticker_formula() {
         ratio_to_big_decimal(&((&max - &min) / min), 6)
     };
 
-    let expected_price_of_eth_token_transfer_usd = get_token_fee_in_usd(
+    let expected_price_of_rbtc_token_transfer_usd = get_token_fee_in_usd(
         &mut ticker,
         TxFeeTypes::Transfer,
         TokenId(0).into(),
@@ -473,7 +473,7 @@ fn test_ticker_formula() {
         None,
     );
 
-    let expected_price_of_eth_token_withdraw_usd = get_token_fee_in_usd(
+    let expected_price_of_rbtc_token_withdraw_usd = get_token_fee_in_usd(
         &mut ticker,
         TxFeeTypes::Withdraw,
         TokenId(0).into(),
@@ -485,7 +485,7 @@ fn test_ticker_formula() {
     // Cost of the transfer and withdraw in USD should be the same for all tokens up to +/- 3 digits
     // (mantissa len == 11)
     let threshold = BigDecimal::from_str("0.01").unwrap();
-    for token in &[TestToken::eth(), TestToken::expensive()] {
+    for token in &[TestToken::rbtc(), TestToken::expensive()] {
         let transfer_fee = get_token_fee_in_usd(
             &mut ticker,
             TxFeeTypes::Transfer,
@@ -494,11 +494,11 @@ fn test_ticker_formula() {
             None,
             None,
         );
-        let expected_fee = expected_price_of_eth_token_transfer_usd.clone() * token.risk_factor();
+        let expected_fee = expected_price_of_rbtc_token_transfer_usd.clone() * token.risk_factor();
         let transfer_diff = get_relative_diff(&transfer_fee, &expected_fee);
         assert!(
                 transfer_diff <= threshold.clone(),
-                "token transfer fee is above eth fee threshold: <{:?}: {}, ETH: {}, diff: {}, threshold: {}>",
+                "token transfer fee is above rbtc fee threshold: <{:?}: {}, RBTC: {}, diff: {}, threshold: {}>",
                 token.id,
                 format_with_dot(&transfer_fee, 6),
                 format_with_dot(&expected_fee, 6),
@@ -513,11 +513,11 @@ fn test_ticker_formula() {
             None,
             None,
         );
-        let expected_fee = expected_price_of_eth_token_withdraw_usd.clone() * token.risk_factor();
+        let expected_fee = expected_price_of_rbtc_token_withdraw_usd.clone() * token.risk_factor();
         let withdraw_diff = get_relative_diff(&withdraw_fee, &expected_fee);
         assert!(
                 withdraw_diff <= threshold.clone(),
-                "token withdraw fee is above eth fee threshold: <{:?}: {}, ETH: {}, diff: {}, threshold: {}>",
+                "token withdraw fee is above rbtc fee threshold: <{:?}: {}, RBTC: {}, diff: {}, threshold: {}>",
                 token.id,
                 format_with_dot(&withdraw_fee, 6),
                 format_with_dot(&expected_fee, 6),
@@ -552,7 +552,7 @@ fn test_ticker_formula() {
                 None,
             );
 
-            let expected_price_of_eth_token_fast_withdraw_usd = get_token_fee_in_usd(
+            let expected_price_of_rbtc_token_fast_withdraw_usd = get_token_fee_in_usd(
                 &mut ticker,
                 TxFeeTypes::FastWithdraw,
                 TokenId(0).into(),
@@ -561,11 +561,11 @@ fn test_ticker_formula() {
                 None,
             );
             let expected_fee =
-                expected_price_of_eth_token_fast_withdraw_usd.clone() * token.risk_factor();
+                expected_price_of_rbtc_token_fast_withdraw_usd.clone() * token.risk_factor();
             let fast_withdraw_diff = get_relative_diff(&fast_withdraw_fee, &expected_fee);
             assert!(
                 fast_withdraw_diff <= threshold.clone(),
-                "token fast withdraw fee is above eth fee threshold: <{:?}: {}, ETH: {}, diff: {}, threshold: {}>",
+                "token fast withdraw fee is above rbtc fee threshold: <{:?}: {}, RBTC: {}, diff: {}, threshold: {}>",
                 token.id,
                 format_with_dot(&fast_withdraw_fee, 6),
                 format_with_dot(&expected_fee, 6),

--- a/core/bin/zksync_api/src/fee_ticker/ticker_api/coingecko.rs
+++ b/core/bin/zksync_api/src/fee_ticker/ticker_api/coingecko.rs
@@ -43,7 +43,7 @@ impl CoinGeckoAPI {
             }
         }
 
-        // Add ETH manually because coingecko API doesn't return address for it.
+        // Add RBTC manually because coingecko API doesn't return address for it.
         token_ids.insert(Address::default(), String::from("rootstock"));
 
         Ok(Self {
@@ -100,10 +100,10 @@ impl TokenPriceAPI for CoinGeckoAPI {
             .take(6)
             .map(|token_price| token_price.1);
 
-        // We use max price for ETH token because we spend ETH with each commit and collect token
-        // so it is in our interest to assume highest price for ETH.
-        // Theoretically we should use min and max price for ETH in our ticker formula when we
-        // calculate fee for tx with ETH token. Practically if we use only max price foe ETH it is fine because
+        // We use max price for RBTC token because we spend RBTC with each commit and collect token
+        // so it is in our interest to assume highest price for RBTC.
+        // Theoretically we should use min and max price for RBTC in our ticker formula when we
+        // calculate fee for tx with RBTC token. Practically if we use only max price foe RBTC it is fine because
         // we don't need to sell this token lnd price only affects ZKP cost of such tx which is negligible.
         // For other tokens we use average price
         let usd_price = if token.id.0 == 0 {
@@ -165,7 +165,7 @@ mod tests {
         let ticker_url = parse_env("FEE_TICKER_COINGECKO_BASE_URL");
         let client = reqwest::Client::new();
         let api = CoinGeckoAPI::new(client, ticker_url).await.unwrap();
-        let token = Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20);
+        let token = Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20);
         api.get_price(&token)
             .await
             .expect("Failed to get data from ticker");

--- a/core/bin/zksync_api/src/fee_ticker/ticker_api/coinmarkercap.rs
+++ b/core/bin/zksync_api/src/fee_ticker/ticker_api/coinmarkercap.rs
@@ -98,7 +98,7 @@ mod test {
         let ticker_url = parse_env("FEE_TICKER_COINMARKETCAP_BASE_URL");
         let client = reqwest::Client::new();
         let api = CoinMarketCapAPI::new(client, ticker_url);
-        let token = Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20);
+        let token = Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20);
         runtime
             .block_on(api.get_price(&token))
             .expect("Failed to get data from ticker");
@@ -116,10 +116,10 @@ mod test {
         "notice": null
     },
     "data": {
-        "ETH": {
+        "RBTC": {
             "id": 1027,
             "name": "Rootstock",
-            "symbol": "ETH",
+            "symbol": "RBTC",
             "slug": "rootstock",
             "num_market_pairs": 5153,
             "date_added": "2015-08-07T00:00:00.000Z",
@@ -150,8 +150,8 @@ mod test {
             serde_json::from_str::<CoinmarketCapResponse>(example).expect("serialization failed");
         let token_data = resp
             .data
-            .get(&TokenLike::Symbol("ETH".to_string()))
-            .expect("ETH data not found");
+            .get(&TokenLike::Symbol("RBTC".to_string()))
+            .expect("RBTC data not found");
         let quote = token_data
             .quote
             .get(&TokenLike::Symbol("USD".to_string()))

--- a/core/bin/zksync_api/src/fee_ticker/ticker_info.rs
+++ b/core/bin/zksync_api/src/fee_ticker/ticker_info.rs
@@ -55,7 +55,7 @@ pub trait FeeTickerInfo: FeeTickerClone + Send + Sync + 'static {
     /// Get last price for token from ticker info
     async fn get_last_token_price(&self, token: TokenLike) -> Result<TokenPrice, PriceError>;
 
-    /// Get current gas price in ETH
+    /// Get current gas price in RBTC
     async fn get_gas_price_wei(&self) -> Result<BigUint, anyhow::Error>;
 
     async fn get_token(&self, token: TokenLike) -> Result<Token, anyhow::Error>;
@@ -214,7 +214,7 @@ impl FeeTickerInfo for TickerInfo {
         Err(PriceError::db_error("No price stored in database"))
     }
 
-    /// Get current gas price in ETH
+    /// Get current gas price in RBTC
     async fn get_gas_price_wei(&self) -> Result<BigUint, anyhow::Error> {
         let start = Instant::now();
 

--- a/core/bin/zksync_api/src/fee_ticker/validator/mod.rs
+++ b/core/bin/zksync_api/src/fee_ticker/validator/mod.rs
@@ -95,7 +95,7 @@ impl<W: TokenWatcher> MarketUpdater<W> {
 /// Fee token validator decides whether certain ERC20 token is suitable for paying fees.
 #[derive(Debug, Clone)]
 pub struct FeeTokenValidator {
-    // Storage for unconditionally valid tokens, such as ETH
+    // Storage for unconditionally valid tokens, such as RBTC
     unconditionally_valid: HashSet<Address>,
     tokens_cache: TokenCacheWrapper,
     available_time: chrono::Duration,
@@ -198,7 +198,7 @@ mod tests {
         let phnx_token = Token::new(TokenId(2), phnx_token_address, "PHNX", 18, TokenKind::ERC20);
 
         let eth_address = Address::from_str("0000000000000000000000000000000000000000").unwrap();
-        let eth_token = Token::new(TokenId(2), eth_address, "ETH", 18, TokenKind::ERC20);
+        let eth_token = Token::new(TokenId(2), eth_address, "RBTC", 18, TokenKind::ERC20);
         let all_tokens = vec![dai_token.clone(), phnx_token.clone()];
 
         let mut market = HashMap::new();

--- a/core/bin/zksync_api/src/fee_ticker/validator/watcher.rs
+++ b/core/bin/zksync_api/src/fee_ticker/validator/watcher.rs
@@ -36,7 +36,7 @@ impl UniswapTokenWatcher {
         let start = Instant::now();
 
         let query = format!(
-            "{{token(id: \"{:#x}\"){{totalLiquidity, derivedETH}}}}",
+            "{{token(id: \"{:#x}\"){{totalLiquidity, derivedRBTC}}}}",
             address
         );
 
@@ -67,8 +67,8 @@ impl UniswapTokenWatcher {
 
         let volume = if let Some(token) = response.data.token {
             let total_liquidity: BigDecimal = token.total_liquidity.parse()?;
-            let derived_eth: BigDecimal = token.derived_eth.parse()?;
-            total_liquidity * derived_eth
+            let derived_rbtc: BigDecimal = token.derived_rbtc.parse()?;
+            total_liquidity * derived_rbtc
         } else {
             BigDecimal::zero()
         };
@@ -99,9 +99,9 @@ pub struct TokenResponse {
     /// Total liquidity in token itself
     #[serde(rename = "totalLiquidity")]
     pub total_liquidity: String,
-    /// Price of token in eth
-    #[serde(rename = "derivedETH")]
-    pub derived_eth: String,
+    /// Price of token in rbtc
+    #[serde(rename = "derivedRBTC")]
+    pub derived_rbtc: String,
 }
 
 #[async_trait::async_trait]

--- a/core/lib/circuit/src/witness/tests/change_pubkey_offchain.rs
+++ b/core/lib/circuit/src/witness/tests/change_pubkey_offchain.rs
@@ -15,7 +15,7 @@ use crate::witness::{
     utils::SigDataInput,
 };
 
-const FEE_TOKEN: TokenId = TokenId(0); // ETH
+const FEE_TOKEN: TokenId = TokenId(0); // RBTC
 
 /// Basic check for execution of `ChangePubKeyOp` in circuit.
 /// Here we generate an empty account and change its public key.

--- a/core/lib/circuit/src/witness/tests/deposit.rs
+++ b/core/lib/circuit/src/witness/tests/deposit.rs
@@ -81,10 +81,10 @@ fn test_deposit_zero_address() {
 fn test_deposit_existing_account() {
     // Data for building a test vector: tuples of (token_id, amount).
     let test_vector = vec![
-        (0, 1),             // Small deposit in ETH.
-        (0, 0),             // 0 deposit in ETH.
-        (0, std::u64::MAX), // Big amount in ETH.
-        (2, 1),             // Non-ETH token.
+        (0, 1),             // Small deposit in RBTC.
+        (0, 0),             // 0 deposit in RBTC.
+        (0, std::u64::MAX), // Big amount in RBTC.
+        (2, 1),             // Non-RBTC token.
     ];
 
     for (token_id, token_amount) in test_vector {

--- a/core/lib/circuit/src/witness/tests/mod.rs
+++ b/core/lib/circuit/src/witness/tests/mod.rs
@@ -59,7 +59,7 @@ mod withdraw_nft;
 /// - WithdrawNFT operation
 ///
 fn apply_many_ops() -> ZkSyncCircuit<'static, Bn256> {
-    const ETH_TOKEN: TokenId = TokenId(0);
+    const RBTC_TOKEN: TokenId = TokenId(0);
     const NNM_TOKEN: TokenId = TokenId(2);
 
     // Create two accounts: we will perform all the operations with the first one,
@@ -79,8 +79,8 @@ fn apply_many_ops() -> ZkSyncCircuit<'static, Bn256> {
 
     // Deposit two types of tokens on the account.
     let deposit_data = [
-        (ETH_TOKEN, 1000u32), // 1000 of ETH
-        (NNM_TOKEN, 2000u32), // 2000 of token with ID 2
+        (RBTC_TOKEN, 1000u32), // 1000 of RBTC
+        (NNM_TOKEN, 2000u32),  // 2000 of token with ID 2
     ];
     let deposit_ops = deposit_data
         .iter()
@@ -94,12 +94,12 @@ fn apply_many_ops() -> ZkSyncCircuit<'static, Bn256> {
             account_id: account.id,
         });
 
-    // Transfer ETH to an existing account.
+    // Transfer RBTC to an existing account.
     let transfer_op = TransferOp {
         tx: account
             .zksync_account
             .sign_transfer(
-                ETH_TOKEN,
+                RBTC_TOKEN,
                 "",
                 BigUint::from(97u32),
                 BigUint::from(3u32),

--- a/core/lib/crypto/src/params.rs
+++ b/core/lib/crypto/src/params.rs
@@ -97,7 +97,7 @@ pub fn max_fungible_token_id() -> TokenId {
     TokenId(number_of_processable_tokens() as u32 - 1)
 }
 
-pub const ETH_TOKEN_ID: TokenId = TokenId(0);
+pub const RBTC_TOKEN_ID: TokenId = TokenId(0);
 
 pub const ACCOUNT_ID_BIT_WIDTH: usize = 32;
 

--- a/core/lib/eth_client/src/clients/http_client.rs
+++ b/core/lib/eth_client/src/clients/http_client.rs
@@ -336,17 +336,17 @@ impl<S: EthereumSigner> ETHDirectClient<S> {
         }
     }
 
-    pub async fn eth_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
+    pub async fn rbtc_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
         #[cfg(feature = "with-metrics")]
         let start = Instant::now();
         let balance = self.inner.web3.eth().balance(address, None).await?;
         #[cfg(feature = "with-metrics")]
-        metrics::histogram!("eth_client.direct.eth_balance", start.elapsed());
+        metrics::histogram!("eth_client.direct.rbtc_balance", start.elapsed());
         Ok(balance)
     }
 
-    pub async fn sender_eth_balance(&self) -> Result<U256, anyhow::Error> {
-        self.eth_balance(self.inner.sender_account).await
+    pub async fn sender_rbtc_balance(&self) -> Result<U256, anyhow::Error> {
+        self.rbtc_balance(self.inner.sender_account).await
     }
 
     pub async fn allowance(

--- a/core/lib/eth_client/src/clients/mock.rs
+++ b/core/lib/eth_client/src/clients/mock.rs
@@ -172,7 +172,7 @@ impl MockEthereum {
         unreachable!()
     }
 
-    pub async fn sender_eth_balance(&self) -> Result<U256, Error> {
+    pub async fn sender_rbtc_balance(&self) -> Result<U256, Error> {
         unreachable!()
     }
 
@@ -189,7 +189,7 @@ impl MockEthereum {
         unreachable!()
     }
 
-    pub async fn eth_balance(&self, _address: Address) -> Result<U256, Error> {
+    pub async fn rbtc_balance(&self, _address: Address) -> Result<U256, Error> {
         unreachable!()
     }
 

--- a/core/lib/eth_client/src/clients/multiplexer.rs
+++ b/core/lib/eth_client/src/clients/multiplexer.rs
@@ -106,8 +106,8 @@ impl MultiplexerEthereumClient {
         multiple_call!(self, get_gas_price());
     }
 
-    pub async fn sender_eth_balance(&self) -> Result<U256, anyhow::Error> {
-        multiple_call!(self, sender_eth_balance());
+    pub async fn sender_rbtc_balance(&self) -> Result<U256, anyhow::Error> {
+        multiple_call!(self, sender_rbtc_balance());
     }
 
     pub async fn sign_prepared_tx(
@@ -148,8 +148,8 @@ impl MultiplexerEthereumClient {
         multiple_call!(self, failure_reason(tx_hash));
     }
 
-    pub async fn eth_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
-        multiple_call!(self, eth_balance(address));
+    pub async fn rbtc_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
+        multiple_call!(self, rbtc_balance(address));
     }
 
     pub async fn allowance(

--- a/core/lib/eth_client/src/rootstock_gateway.rs
+++ b/core/lib/eth_client/src/rootstock_gateway.rs
@@ -127,8 +127,8 @@ impl RootstockGateway {
         delegate_call!(self.get_gas_price())
     }
     /// Returns the account balance.
-    pub async fn sender_eth_balance(&self) -> Result<U256, anyhow::Error> {
-        delegate_call!(self.sender_eth_balance())
+    pub async fn sender_rbtc_balance(&self) -> Result<U256, anyhow::Error> {
+        delegate_call!(self.sender_rbtc_balance())
     }
 
     /// Signs the transaction given the previously encoded data.
@@ -174,8 +174,8 @@ impl RootstockGateway {
     }
 
     /// Auxiliary function that returns the balance of the account on Rootstock.
-    pub async fn eth_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
-        delegate_call!(self.eth_balance(address))
+    pub async fn rbtc_balance(&self, address: Address) -> Result<U256, anyhow::Error> {
+        delegate_call!(self.rbtc_balance(address))
     }
 
     pub async fn allowance(

--- a/core/lib/prover_utils/examples/generate_exit_proof.rs
+++ b/core/lib/prover_utils/examples/generate_exit_proof.rs
@@ -69,7 +69,7 @@ struct Opt {
     #[structopt(long)]
     address: Address,
 
-    /// Token to withdraw - "ETH" or address of the ERC20 token
+    /// Token to withdraw - "RBTC" or address of the ERC20 token
     #[structopt(long)]
     token: String,
 }

--- a/core/lib/state/benches/criterion/ops.rs
+++ b/core/lib/state/benches/criterion/ops.rs
@@ -18,7 +18,7 @@ use zksync_types::{
 use zksync_state::state::ZkSyncState;
 use zksync_types::tx::{ChangePubKeyECDSAData, ChangePubKeyEthAuthData};
 
-const ETH_TOKEN_ID: TokenId = TokenId(0x00);
+const RBTC_TOKEN_ID: TokenId = TokenId(0x00);
 // The amount is not important, since we always work with 1 account.
 // We use some small non-zero value, so the overhead for cloning will not be big.
 const ACCOUNTS_AMOUNT: AccountId = AccountId(10);
@@ -34,11 +34,11 @@ fn generate_account() -> (H256, PrivateKey, Account) {
 
     let eth_sk = H256::random();
     let address = PackedEthSignature::address_from_private_key(&eth_sk)
-        .expect("Can't get address from the ETH secret key");
+        .expect("Can't get address from the RBTC secret key");
 
     let mut account = Account::default_with_address(&address);
     account.pub_key_hash = PubKeyHash::from_privkey(&sk);
-    account.set_balance(ETH_TOKEN_ID, default_balance);
+    account.set_balance(RBTC_TOKEN_ID, default_balance);
 
     (eth_sk, sk, account)
 }
@@ -73,7 +73,7 @@ fn apply_transfer_to_new_op(b: &mut Bencher<'_>) {
         AccountId(0),
         from_account.address,
         Address::random(),
-        ETH_TOKEN_ID,
+        RBTC_TOKEN_ID,
         10u32.into(),
         1u32.into(),
         Nonce(0),
@@ -112,7 +112,7 @@ fn apply_transfer_tx(b: &mut Bencher<'_>) {
         AccountId(0),
         from_account.address,
         to_account.address,
-        ETH_TOKEN_ID,
+        RBTC_TOKEN_ID,
         10u32.into(),
         1u32.into(),
         Nonce(0),
@@ -147,7 +147,7 @@ fn apply_full_exit_tx(b: &mut Bencher<'_>) {
     let full_exit = FullExit {
         account_id: AccountId(0),
         eth_address: from_account.address,
-        token: ETH_TOKEN_ID,
+        token: RBTC_TOKEN_ID,
         is_legacy: false,
     };
 
@@ -175,7 +175,7 @@ fn apply_deposit_tx(b: &mut Bencher<'_>) {
     let deposit = Deposit {
         from: Address::random(),
         to: to_account.address,
-        token: ETH_TOKEN_ID,
+        token: RBTC_TOKEN_ID,
         amount: 10u32.into(),
     };
 
@@ -205,7 +205,7 @@ fn apply_withdraw_tx(b: &mut Bencher<'_>) {
         AccountId(0),
         from_account.address,
         Address::random(),
-        ETH_TOKEN_ID,
+        RBTC_TOKEN_ID,
         10u32.into(),
         1u32.into(),
         Nonce(0),

--- a/core/lib/state/src/handler/close.rs
+++ b/core/lib/state/src/handler/close.rs
@@ -52,7 +52,7 @@ impl TxHandler<Close> for ZkSyncState {
         ));
 
         let fee = CollectedFee {
-            token: params::ETH_TOKEN_ID,
+            token: params::RBTC_TOKEN_ID,
             amount: BigUint::from(0u32),
         };
 

--- a/core/lib/state/src/tests/collect_fee.rs
+++ b/core/lib/state/src/tests/collect_fee.rs
@@ -4,7 +4,7 @@ use num::{BigUint, Zero};
 use zksync_types::{account::AccountUpdate, AccountId, TokenId};
 
 /// Checks if fees are collected correctly.
-/// Fees are not only in ETH and may be zero.
+/// Fees are not only in RBTC and may be zero.
 #[test]
 fn success() {
     let mut tb = PlasmaTestBuilder::new();

--- a/core/lib/storage/migrations/2020-04-07-065600_init_storage/up.sql
+++ b/core/lib/storage/migrations/2020-04-07-065600_init_storage/up.sql
@@ -93,7 +93,7 @@ CREATE TABLE executed_transactions (
 -- -------------- --
 
 -- Token types known to the ZKSync node.
--- By default has the ETH token only (see the `INSERT` statement in the end of the file).
+-- By default has the RBTC token only (see the `INSERT` statement in the end of the file).
 CREATE TABLE tokens (
     id INTEGER NOT NULL PRIMARY KEY,
     address TEXT NOT NULL,
@@ -154,8 +154,8 @@ CREATE TABLE account_pubkey_updates (
 
 -- Table for the account balances. One account can have several balances,
 -- but every balance account has must have an unique token (meaning that
--- there may be user with `ETH` and `ERC-20` balances, but not with `ETH`
--- and `ETH` balances).
+-- there may be user with `RBTC` and `ERC-20` balances, but not with `RBTC`
+-- and `RBTC` balances).
 CREATE TABLE balances (
     account_id BIGINT REFERENCES accounts(id) ON UPDATE CASCADE ON DELETE CASCADE,
     coin_id INTEGER REFERENCES tokens(id) ON UPDATE CASCADE,
@@ -335,10 +335,9 @@ CREATE EXTENSION IF NOT EXISTS tablefunc;
 -- Data insertion section --
 -- ---------------------- --
 
--- TODO: We may need to change this part to replace `ETH` with `RBTC`
--- Add ETH token
+-- Add RBTC token
 INSERT INTO tokens
 VALUES (0,
         '0x0000000000000000000000000000000000000000',
-        'ETH',
+        'RBTC',
         18);

--- a/core/lib/storage/src/tests/chain/operations_ext/setup.rs
+++ b/core/lib/storage/src/tests/chain/operations_ext/setup.rs
@@ -33,7 +33,7 @@ impl TransactionsHistoryTestSetup {
         let mut nft_token = Token::new_nft(TokenId(100000), "NFT-100000");
         nft_token.address = Address::random();
         let tokens = vec![
-            Token::new(TokenId(0), Address::zero(), "ETH", 18, TokenKind::ERC20), // used for deposits, swaps
+            Token::new(TokenId(0), Address::zero(), "RBTC", 18, TokenKind::ERC20), // used for deposits, swaps
             Token::new(TokenId(1), Address::random(), "DAI", 18, TokenKind::ERC20), // used for transfers, swaps
             Token::new(TokenId(2), Address::random(), "FAU", 6, TokenKind::ERC20), // used for withdraws
             nft_token, // used for nft withdrawals

--- a/core/lib/storage/src/tests/tokens.rs
+++ b/core/lib/storage/src/tests/tokens.rs
@@ -35,7 +35,7 @@ async fn tokens_storage(mut storage: StorageProcessor<'_>) -> QueryResult<()> {
     let eth_token = Token {
         id: TokenId(0),
         address: "0000000000000000000000000000000000000000".parse().unwrap(),
-        symbol: "ETH".into(),
+        symbol: "RBTC".into(),
         decimals: 18,
         kind: TokenKind::ERC20,
         is_nft: false,

--- a/core/lib/storage/src/tokens/mod.rs
+++ b/core/lib/storage/src/tokens/mod.rs
@@ -180,7 +180,7 @@ impl<'a, 'c> TokensSchema<'a, 'c> {
     }
 
     /// Loads all the stored tokens from the database.
-    /// Alongside with the tokens added via `store_token` method, the default `ETH` token
+    /// Alongside with the tokens added via `store_token` method, the default `RBTC` token
     /// is returned.
     pub async fn load_tokens(&mut self) -> QueryResult<HashMap<TokenId, Token>> {
         let tokens = self.load_tokens_asc(TokenId(0), None).await?;
@@ -290,7 +290,7 @@ impl<'a, 'c> TokensSchema<'a, 'c> {
             .map(|t| TokenId(t.token_id as u32))
             .collect();
 
-        // ETH always has enough market volume
+        // RBTC has always got enough market volume
         if tokens_to_check.contains(&0) && !result.contains(&TokenId(0)) {
             result.insert(TokenId(0));
         }

--- a/core/lib/types/benches/criterion/txs/mod.rs
+++ b/core/lib/types/benches/criterion/txs/mod.rs
@@ -23,7 +23,7 @@ use zksync_types::{
 // Local uses
 use zksync_types::tx::{ChangePubKeyECDSAData, ChangePubKeyEthAuthData};
 
-const ETH_TOKEN_ID: TokenId = TokenId(0x00);
+const RBTC_TOKEN_ID: TokenId = TokenId(0x00);
 
 /// Creates a random ZKSync account.
 fn generate_account() -> (H256, PrivateKey, Account) {
@@ -38,7 +38,7 @@ fn generate_account() -> (H256, PrivateKey, Account) {
 
     let mut account = Account::default_with_address(&address);
     account.pub_key_hash = PubKeyHash::from_privkey(&sk);
-    account.set_balance(ETH_TOKEN_ID, default_balance);
+    account.set_balance(RBTC_TOKEN_ID, default_balance);
 
     (eth_sk, sk, account)
 }
@@ -64,7 +64,7 @@ impl TxBenchSetup {
             AccountId(0),
             self.account.address,
             Address::random(),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             10u32.into(),
             1u32.into(),
             Nonce(0),
@@ -85,7 +85,7 @@ impl TxBenchSetup {
             AccountId(0),
             self.account.address,
             Address::random(),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             10u32.into(),
             1u32.into(),
             Nonce(0),
@@ -109,7 +109,7 @@ impl TxBenchSetup {
             AccountId(0),
             self.account.address,
             PubKeyHash::from_privkey(&new_sk),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             Default::default(),
             Nonce(0),
             Default::default(),
@@ -142,7 +142,7 @@ impl TxBenchSetup {
         let mut tx = ForcedExit::new_signed(
             AccountId(0),
             self.account.address,
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             Default::default(),
             Nonce(0),
             Default::default(),
@@ -164,7 +164,7 @@ impl TxBenchSetup {
             H256::random(),
             Address::random(),
             Default::default(),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             Nonce(0),
             &self.private_key,
         )
@@ -183,7 +183,7 @@ impl TxBenchSetup {
             self.account.address,
             self.account.address,
             TokenId(MIN_NFT_TOKEN_ID),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             Default::default(),
             Nonce(0),
             Default::default(),
@@ -237,7 +237,7 @@ impl TxBenchSetup {
             (order_0, order_1),
             (BigUint::from(1u64), BigUint::from(1u64)),
             Default::default(),
-            ETH_TOKEN_ID,
+            RBTC_TOKEN_ID,
             &self.private_key,
         )
         .expect("swap creation failed");

--- a/core/lib/types/src/helpers.rs
+++ b/core/lib/types/src/helpers.rs
@@ -240,9 +240,9 @@ mod test {
             ),
             (
                 Query {
-                    token: TokenLike::Symbol("ETH".to_string()),
+                    token: TokenLike::Symbol("RBTC".to_string()),
                 },
-                r#"{"token":"ETH"}"#,
+                r#"{"token":"RBTC"}"#,
             ),
             (
                 Query {

--- a/core/lib/types/src/tokens.rs
+++ b/core/lib/types/src/tokens.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt, fs::read_to_string, path::PathBuf, str::FromStr};
 use thiserror::Error;
 
-/// ID of the ETH token in zkSync network.
-pub use zksync_crypto::params::ETH_TOKEN_ID;
+/// ID of the RBTC token in zkSync network.
+pub use zksync_crypto::params::RBTC_TOKEN_ID;
 use zksync_utils::{parse_env, UnsignedRatioSerializeAsDecimal};
 
 use crate::{tx::ChangePubKeyType, AccountId, Address, Log, TokenId, H256, U256};
@@ -25,7 +25,7 @@ pub enum TokenLike {
     Id(TokenId),
     /// Address of the token in the L1.
     Address(Address),
-    /// Symbol associated with token, e.g. "ETH".
+    /// Symbol associated with token, e.g. "RBTC".
     Symbol(String),
 }
 
@@ -83,14 +83,14 @@ impl TokenLike {
     }
 
     /// Checks if the token is Rootstock.
-    pub fn is_eth(&self) -> bool {
+    pub fn is_rbtc(&self) -> bool {
         match self {
             Self::Symbol(symbol) => {
-                // Case-insensitive comparison against `ETH`.
+                // Case-insensitive comparison against `RBTC`.
                 symbol
                     .chars()
                     .map(|c| c.to_ascii_lowercase())
-                    .eq("eth".chars())
+                    .eq("rbtc".chars())
             }
             Self::Address(address) => *address == Address::zero(),
             Self::Id(id) => **id == 0,
@@ -113,11 +113,11 @@ impl TokenLike {
 pub struct Token {
     /// id is used for tx signature and serialization
     pub id: TokenId,
-    /// Contract address of ERC20 token or Address::zero() for "ETH"
+    /// Contract address of ERC20 token or Address::zero() for "RBTC"
     pub address: Address,
-    /// Token symbol (e.g. "ETH" or "USDC")
+    /// Token symbol (e.g. "RBTC" or "USDC")
     pub symbol: String,
-    /// Token precision (e.g. 18 for "ETH" so "1.0" ETH = 10e18 as U256 number)
+    /// Token precision (e.g. 18 for "RBTC" so "1.0" RBTC = 10e18 as U256 number)
     pub decimals: u8,
     pub kind: TokenKind,
     pub is_nft: bool,
@@ -165,7 +165,7 @@ impl Token {
 pub struct TokenInfo {
     /// Address (prefixed with 0x)
     pub address: Address,
-    /// Powers of 10 in 1.0 token (18 for default ETH-like tokens)
+    /// Powers of 10 in 1.0 token (18 for default RBTC-like tokens)
     pub decimals: u8,
     /// Token symbol
     pub symbol: String,
@@ -386,24 +386,24 @@ mod tests {
     }
 
     #[test]
-    fn token_like_is_eth() {
+    fn token_like_is_rbtc() {
         let tokens = vec![
             TokenLike::Address(Address::zero()),
             TokenLike::Id(TokenId(0)),
-            TokenLike::Symbol("ETH".into()),
-            TokenLike::Symbol("eth".into()),
+            TokenLike::Symbol("RBTC".into()),
+            TokenLike::Symbol("rbtc".into()),
         ];
 
         for token in tokens {
-            assert!(token.is_eth());
+            assert!(token.is_rbtc());
         }
     }
 
     #[test]
     fn token_like_to_case_insensitive() {
         assert_eq!(
-            TokenLike::Symbol("ETH".into()).to_lowercase(),
-            TokenLike::Symbol("eth".into())
+            TokenLike::Symbol("RBTC".into()).to_lowercase(),
+            TokenLike::Symbol("rbtc".into())
         );
     }
 }

--- a/core/lib/types/src/tx/primitives/tests.rs
+++ b/core/lib/types/src/tx/primitives/tests.rs
@@ -57,7 +57,7 @@ fn test_empty_batch() {
 /// Checks the correctness of the message `EthBatchSignData::new()` returns.
 #[test]
 fn test_batch_message() {
-    let token = Token::new(TokenId(0), Default::default(), "ETH", 18, TokenKind::ERC20);
+    let token = Token::new(TokenId(0), Default::default(), "RBTC", 18, TokenKind::ERC20);
     let transfer = get_transfer();
     let withdraw = get_withdraw();
     let change_pub_key = get_change_pub_key();
@@ -82,7 +82,7 @@ fn test_batch_message() {
         Nonce: 13",
         amount1 = format_units(transfer.amount, 18),
         amount2 = format_units(withdraw.amount, 18),
-        token = "ETH",
+        token = "RBTC",
         to1 = transfer.to,
         to2 = withdraw.to,
         fee = format_units(withdraw.fee, 18),
@@ -117,7 +117,7 @@ fn test_batch_message() {
         Withdraw {amount} {token} to: {to:?}\n\
         Nonce: 0",
         fee = format_units(transfer.fee, 18),
-        token = "ETH",
+        token = "RBTC",
         amount = format_units(withdraw.amount, 18),
         to = withdraw.to
     );

--- a/core/lib/types/src/tx/zksync_tx.rs
+++ b/core/lib/types/src/tx/zksync_tx.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 use zksync_basic_types::{AccountId, Address};
-use zksync_crypto::params::ETH_TOKEN_ID;
+use zksync_crypto::params::RBTC_TOKEN_ID;
 
 use crate::{
     operations::{ChangePubKeyOp, MintNFTOp},
@@ -243,7 +243,7 @@ impl ZkSyncTx {
         match self {
             ZkSyncTx::Transfer(tx) => tx.token,
             ZkSyncTx::Withdraw(tx) => tx.token,
-            ZkSyncTx::Close(_) => ETH_TOKEN_ID,
+            ZkSyncTx::Close(_) => RBTC_TOKEN_ID,
             ZkSyncTx::ChangePubKey(tx) => tx.fee_token,
             ZkSyncTx::ForcedExit(tx) => tx.token,
             ZkSyncTx::Swap(tx) => tx.fee_token,

--- a/core/tests/loadnext/README.md
+++ b/core/tests/loadnext/README.md
@@ -76,6 +76,7 @@ OPERATIONS_PER_ACCOUNT
 #
 # Note that we use ERC-20 token since we can't easily mint a lot of ETH on
 # Rinkeby or Ropsten without caring about collecting it back.
+# TODO: ^^^ lose references to non-rootstock networks
 MAIN_TOKEN
 ```
 

--- a/core/tests/loadnext/src/corrupted_tx.rs
+++ b/core/tests/loadnext/src/corrupted_tx.rs
@@ -331,7 +331,7 @@ mod tests {
     fn create_transfer(account: &ZkSyncAccount) -> (ZkSyncTx, Option<PackedEthSignature>) {
         let (transfer, eth_signature) = account.sign_transfer(
             TokenId(0),
-            "ETH",
+            "RBTC",
             AMOUNT.into(),
             FEE.into(),
             &Address::repeat_byte(0x7e),
@@ -369,7 +369,7 @@ mod tests {
         let transfer = create_transfer(&account);
 
         let (modified_transfer, _eth_signature) =
-            transfer.zero_fee(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.zero_fee(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert_eq!(unwrap_transfer(modified_transfer).fee, 0u64.into());
     }
@@ -381,7 +381,7 @@ mod tests {
         let transfer = create_transfer(&account);
 
         let (modified_transfer, _eth_signature) =
-            transfer.too_big_amount(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.too_big_amount(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert!(unwrap_transfer(modified_transfer).amount > AMOUNT.into());
     }
@@ -393,7 +393,7 @@ mod tests {
         let transfer = create_transfer(&account);
 
         let (modified_transfer, _eth_signature) =
-            transfer.not_packable_amount(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.not_packable_amount(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert!(!is_token_amount_packable(
             &unwrap_transfer(modified_transfer).amount
@@ -407,7 +407,7 @@ mod tests {
         let transfer = create_transfer(&account);
 
         let (modified_transfer, _eth_signature) =
-            transfer.not_packable_fee(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.not_packable_fee(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert!(!is_fee_amount_packable(
             &unwrap_transfer(modified_transfer).fee
@@ -421,7 +421,7 @@ mod tests {
         let transfer = create_transfer(&account);
 
         let (modified_transfer, _eth_signature) =
-            transfer.nonexistent_token(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.nonexistent_token(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert_ne!(unwrap_transfer(modified_transfer).token, TokenId(0));
     }
@@ -434,7 +434,7 @@ mod tests {
         let current_eth_signature = transfer.1.clone();
 
         let (_modified_transfer, new_eth_signature) =
-            transfer.bad_eth_signature(account.eth_account_data.unwrap_eoa_pk(), "ETH", 18);
+            transfer.bad_eth_signature(account.eth_account_data.unwrap_eoa_pk(), "RBTC", 18);
 
         assert_ne!(current_eth_signature, new_eth_signature);
     }

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -62,17 +62,17 @@ impl Executor {
         Ok(final_resultion)
     }
 
-    /// Verifies that onchain ETH balance for the main account is sufficient to run the loadtest.
+    /// Verifies that onchain RBTC balance for the main account is sufficient to run the loadtest.
     async fn check_onchain_balance(&mut self) -> anyhow::Result<()> {
         vlog::info!("Master Account: Checking onchain balance...");
         let master_wallet = &mut self.pool.master_wallet;
         let rootstock = master_wallet.rootstock(&self.config.web3_url).await?;
 
-        let eth_balance = rootstock.balance().await?;
-        if eth_balance < 2u64.pow(17).into() {
+        let rbtc_balance = rootstock.balance().await?;
+        if rbtc_balance < 2u64.pow(17).into() {
             anyhow::bail!(
-                "ETH balance is too low to safely perform the loadtest: {}",
-                eth_balance
+                "RBTC balance is too low to safely perform the loadtest: {}",
+                rbtc_balance
             );
         }
 
@@ -237,7 +237,7 @@ impl Executor {
             // We don't actually care whether transactions will be successful or not; at worst we will not use
             // priority operations in test.
             let _ = rootstock
-                .transfer("ETH", eth_to_distribute, target_address)
+                .transfer("RBTC", eth_to_distribute, target_address)
                 .await;
 
             // And then we will prepare an L2 transaction.
@@ -315,7 +315,7 @@ impl Executor {
     ///
     /// - Spawning the `ReportCollector`.
     /// - Distributing ERC-20 token in L2 among test wallets via `Transfer` operation.
-    /// - Distributing ETH in L1 among test wallets in order to make them able to perform priority operations.
+    /// - Distributing RBTC in L1 among test wallets in order to make them able to perform priority operations.
     /// - Spawning test account routine futures.
     /// - Collecting all the spawned tasks and returning them to the caller.
     async fn send_initial_transfers(
@@ -414,7 +414,7 @@ impl Executor {
         Ok((report_collector_future, account_futures))
     }
 
-    /// Calculates amount of ETH to be distributed per account in order to make them
+    /// Calculates amount of RBTC to be distributed per account in order to make them
     /// able to perform priority operations.
     async fn eth_amount_to_distribute(&self) -> anyhow::Result<U256> {
         let rootstock = self

--- a/core/tests/testkit/src/account_set.rs
+++ b/core/tests/testkit/src/account_set.rs
@@ -22,7 +22,7 @@ impl AccountSet {
         &self,
         from: ETHAccountId,
         to: ZKSyncAccountId,
-        token: Option<Address>, // None for ETH
+        token: Option<Address>, // None for RBTC
         amount: BigUint,
     ) -> (Vec<TransactionReceipt>, PriorityOp) {
         let from = &self.eth_accounts[from.0];
@@ -33,16 +33,16 @@ impl AccountSet {
                 .await
                 .expect("erc20 deposit should not fail")
         } else {
-            from.deposit_eth(amount, &to.address, None)
+            from.deposit_rbtc(amount, &to.address, None)
                 .await
-                .expect("eth deposit should not fail")
+                .expect("rbtc deposit should not fail")
         }
     }
 
     pub async fn deposit_to_random(
         &self,
         from: ETHAccountId,
-        token: Option<Address>, // None for ETH
+        token: Option<Address>, // None for RBTC
         amount: BigUint,
         rng: &mut impl Rng,
     ) -> (Vec<TransactionReceipt>, PriorityOp) {
@@ -54,9 +54,9 @@ impl AccountSet {
                 .await
                 .expect("erc20 deposit should not fail")
         } else {
-            from.deposit_eth(amount, &to_address, None)
+            from.deposit_rbtc(amount, &to_address, None)
                 .await
-                .expect("eth deposit should not fail")
+                .expect("rbtc deposit should not fail")
         }
     }
 

--- a/core/tests/testkit/src/bin/exodus_test.rs
+++ b/core/tests/testkit/src/bin/exodus_test.rs
@@ -8,7 +8,7 @@
 //! + Check exit with garbage proof.
 //! + Check exit with correct proof for other account, correct proof for this account but other token, correct proof but wrong amount.
 
-use crate::eth_account::{parse_ether, RootstockAccount};
+use crate::eth_account::{parse_rbtc, RootstockAccount};
 use crate::external_commands::{deploy_contracts, get_test_accounts};
 use crate::zksync_account::ZkSyncAccount;
 use num::BigUint;
@@ -487,7 +487,7 @@ async fn exit_test() {
         None,
     );
 
-    let deposit_amount = parse_ether("0.1").unwrap();
+    let deposit_amount = parse_rbtc("0.1").unwrap();
     let tokens = test_setup.get_tokens();
 
     create_verified_initial_state(
@@ -500,7 +500,7 @@ async fn exit_test() {
     .await;
     let verified_accounts_state = test_setup.get_accounts_state().await;
 
-    let expired_deposit_amount = parse_ether("0.3").unwrap();
+    let expired_deposit_amount = parse_rbtc("0.3").unwrap();
     let (expire_count_start_block, expired_priority_ops) = commit_deposit_to_expire(
         &mut test_setup,
         ETHAccountId(0),

--- a/core/tests/testkit/src/bin/gas_price_test.rs
+++ b/core/tests/testkit/src/bin/gas_price_test.rs
@@ -302,7 +302,7 @@ async fn gas_price_test() {
 
     commit_cost_of_deposits(&mut test_setup, 100, Token(TokenId(0)), rng)
         .await
-        .report(&base_cost, "deposit ETH", true);
+        .report(&base_cost, "deposit RBTC", true);
     commit_cost_of_deposits(&mut test_setup, 50, Token(TokenId(1)), rng)
         .await
         .report(&base_cost, "deposit ERC20", true);
@@ -332,14 +332,14 @@ async fn gas_price_test() {
 
     commit_cost_of_full_exits(&mut test_setup, 100, Token(TokenId(0)))
         .await
-        .report(&base_cost, "full exit ETH", true);
+        .report(&base_cost, "full exit RBTC", true);
     commit_cost_of_full_exits(&mut test_setup, 100, Token(TokenId(1)))
         .await
         .report(&base_cost, "full exit ERC20", true);
 
     commit_cost_of_withdrawals(&mut test_setup, 40, Token(TokenId(0)), rng)
         .await
-        .report(&base_cost, "withdrawals ETH", false);
+        .report(&base_cost, "withdrawals RBTC", false);
     commit_cost_of_withdrawals(&mut test_setup, 40, Token(TokenId(1)), rng)
         .await
         .report(&base_cost, "withdrawals ERC20", false);

--- a/core/tests/testkit/src/bin/migration_test.rs
+++ b/core/tests/testkit/src/bin/migration_test.rs
@@ -1,4 +1,4 @@
-use crate::eth_account::{parse_ether, RootstockAccount};
+use crate::eth_account::{parse_rbtc, RootstockAccount};
 use crate::external_commands::{deploy_contracts, get_test_accounts, run_upgrade_franklin};
 use crate::zksync_account::ZkSyncAccount;
 use std::time::Instant;
@@ -80,7 +80,7 @@ async fn migration_test() {
         None,
     );
 
-    let deposit_amount = parse_ether("1.0").unwrap();
+    let deposit_amount = parse_rbtc("1.0").unwrap();
 
     let token = TokenId(0);
     perform_basic_operations(

--- a/core/tests/testkit/src/bin/revert_blocks_test.rs
+++ b/core/tests/testkit/src/bin/revert_blocks_test.rs
@@ -12,7 +12,7 @@ use zksync_testkit::{
 use zksync_types::{BlockNumber, Nonce, TokenId};
 
 use crate::{
-    eth_account::{parse_ether, RootstockAccount},
+    eth_account::{parse_rbtc, RootstockAccount},
     external_commands::{deploy_contracts, get_test_accounts, Contracts},
     zksync_account::ZkSyncAccount,
 };
@@ -78,7 +78,7 @@ async fn execute_blocks(
     number_of_committed_iteration_blocks: u16,
     number_of_reverted_iterations_blocks: u16,
 ) -> (ZkSyncStateInitParams, AccountSet, Block) {
-    let deposit_amount = parse_ether("1.0").unwrap();
+    let deposit_amount = parse_rbtc("1.0").unwrap();
 
     let mut executed_blocks = Vec::new();
     let token = 0;
@@ -99,7 +99,7 @@ async fn execute_blocks(
         ));
     }
     test_setup
-        .get_eth_balance(ETHAccountId(0), TokenId(0))
+        .get_rbtc_balance(ETHAccountId(0), TokenId(0))
         .await;
     for _ in 0..number_of_committed_iteration_blocks - number_of_verified_iteration_blocks {
         let blocks = perform_basic_operations(
@@ -116,7 +116,7 @@ async fn execute_blocks(
         ));
     }
     test_setup
-        .get_eth_balance(ETHAccountId(0), TokenId(0))
+        .get_rbtc_balance(ETHAccountId(0), TokenId(0))
         .await;
 
     let executed_blocks_reverse_order = executed_blocks

--- a/core/tests/testkit/src/scenarios.rs
+++ b/core/tests/testkit/src/scenarios.rs
@@ -10,7 +10,7 @@ use zksync_types::{Nonce, TokenId};
 
 use crate::{
     data_restore::verify_restore,
-    eth_account::{parse_ether, RootstockAccount},
+    eth_account::{parse_rbtc, RootstockAccount},
     external_commands::{deploy_contracts, get_test_accounts},
     state_keeper_utils::spawn_state_keeper,
     zksync_account::ZkSyncAccount,
@@ -98,7 +98,7 @@ pub async fn perform_basic_tests() {
         None,
     );
 
-    let deposit_amount = parse_ether("1.0").unwrap();
+    let deposit_amount = parse_rbtc("1.0").unwrap();
 
     let token = TokenId(1);
     let executed_blocks = perform_basic_operations(

--- a/core/tests/testkit/src/test_setup.rs
+++ b/core/tests/testkit/src/test_setup.rs
@@ -128,7 +128,7 @@ impl TestSetup {
             .cloned()
         {
             Some(balance) => balance,
-            None => self.get_eth_balance(account, token).await,
+            None => self.get_rbtc_balance(account, token).await,
         }
     }
 
@@ -179,8 +179,8 @@ impl TestSetup {
             .eth_accounts_state
             .contains_key(&(eth_account_id, TokenId(0)))
         {
-            // Setup eth balance for fee
-            let balance = self.get_eth_balance(eth_account_id, TokenId(0)).await;
+            // Setup rbtc balance for fee
+            let balance = self.get_rbtc_balance(eth_account_id, TokenId(0)).await;
             self.expected_changes_for_current_block
                 .eth_accounts_state
                 .insert((eth_account_id, TokenId(0)), balance);
@@ -192,7 +192,7 @@ impl TestSetup {
             .contains_key(&(eth_account_id, token.0))
         {
             // Setup token balance
-            let balance = self.get_eth_balance(eth_account_id, token.0).await;
+            let balance = self.get_rbtc_balance(eth_account_id, token.0).await;
             self.expected_changes_for_current_block
                 .eth_accounts_state
                 .insert((eth_account_id, token.0), balance);
@@ -766,11 +766,11 @@ impl TestSetup {
             .sync_accounts_state
             .insert((from, token.0), zksync0_old);
 
-        let mut to_eth_balance = self.get_expected_eth_account_balance(to, token.0).await;
-        to_eth_balance += &amount;
+        let mut to_rbtc_balance = self.get_expected_eth_account_balance(to, token.0).await;
+        to_rbtc_balance += &amount;
         self.expected_changes_for_current_block
             .eth_accounts_state
-            .insert((to, token.0), to_eth_balance);
+            .insert((to, token.0), to_rbtc_balance);
 
         let mut zksync0_old = self
             .get_expected_zksync_account_balance(self.accounts.fee_account_id, token.0)
@@ -876,13 +876,13 @@ impl TestSetup {
             .sync_accounts_state
             .insert((target, token_id.0), 0u64.into());
 
-        let mut target_eth_balance = self
+        let mut target_rbtc_balance = self
             .get_expected_eth_account_balance(target_eth_id, token_id.0)
             .await;
-        target_eth_balance += &target_old;
+        target_rbtc_balance += &target_old;
         self.expected_changes_for_current_block
             .eth_accounts_state
-            .insert((target_eth_id, token_id.0), target_eth_balance);
+            .insert((target_eth_id, token_id.0), target_rbtc_balance);
 
         let mut fee_account_balance = self
             .get_expected_zksync_account_balance(self.accounts.fee_account_id, token_id.0)
@@ -1140,7 +1140,7 @@ impl TestSetup {
         for ((eth_account, token), expected_balance) in
             &self.expected_changes_for_current_block.eth_accounts_state
         {
-            let real_balance = self.get_eth_balance(*eth_account, *token).await;
+            let real_balance = self.get_rbtc_balance(*eth_account, *token).await;
             if expected_balance != &real_balance {
                 println!("eth acc: {}, token: {}", eth_account.0, token);
                 println!("expected: {}", expected_balance);
@@ -1227,13 +1227,13 @@ impl TestSetup {
         result
     }
 
-    pub async fn get_eth_balance(&self, eth_account_id: ETHAccountId, token: TokenId) -> BigUint {
+    pub async fn get_rbtc_balance(&self, eth_account_id: ETHAccountId, token: TokenId) -> BigUint {
         let account = &self.accounts.eth_accounts[eth_account_id.0];
         let result = if token == TokenId(0) {
             account
-                .eth_balance()
+                .rbtc_balance()
                 .await
-                .expect("Failed to get eth balance")
+                .expect("Failed to get rbtc balance")
         } else {
             account
                 .erc20_balance(&self.tokens[&token])

--- a/core/tests/ts-tests/tests/api.test.ts
+++ b/core/tests/ts-tests/tests/api.test.ts
@@ -20,7 +20,7 @@ describe('ZkSync REST API V0.1 tests', () => {
         tester = await Tester.init('localhost', 'HTTP', 'RPC');
         alice = await tester.fundedWallet('1.0');
         let bob = await tester.emptyWallet();
-        for (const token of ['ETH', 'DAI']) {
+        for (const token of ['RBTC', 'DAI']) {
             const thousand = tester.syncProvider.tokenSet.parseToken(token, '1000');
             await tester.testDeposit(alice, token, thousand, true);
             await tester.testChangePubKey(alice, token, false);
@@ -80,17 +80,17 @@ describe('ZkSync REST API V0.2 tests', () => {
         tester = await Tester.init('localhost', 'HTTP', 'REST');
         alice = await tester.fundedWallet('1.0');
         bob = await tester.emptyWallet();
-        for (const token of ['ETH', 'wBTC']) {
+        for (const token of ['RBTC', 'wBTC']) {
             const thousand = tester.syncProvider.tokenSet.parseToken(token, '1000');
             await tester.testDeposit(alice, token, thousand, true);
-            if (token === 'ETH') await tester.testChangePubKey(alice, token, false);
+            if (token === 'RBTC') await tester.testChangePubKey(alice, token, false);
             await tester.testTransfer(alice, bob, token, thousand.div(4));
         }
 
         const handle = await alice.syncTransfer({
             to: bob.address(),
-            token: 'ETH',
-            amount: alice.provider.tokenSet.parseToken('ETH', '1')
+            token: 'RBTC',
+            amount: alice.provider.tokenSet.parseToken('RBTC', '1')
         });
         lastTxHash = handle.txHash;
         lastTxHash.replace('sync-tx:', '0x');
@@ -115,7 +115,7 @@ describe('ZkSync REST API V0.2 tests', () => {
                 limit: 10,
                 direction: 'older'
             },
-            'ETH'
+            'RBTC'
         );
         expect(
             ethTxs.list.length,
@@ -205,14 +205,14 @@ describe('ZkSync REST API V0.2 tests', () => {
     });
 
     it('should check api v0.2 fee scope', async () => {
-        const fee = await provider.getTransactionFee('Withdraw', alice.address(), 'ETH');
+        const fee = await provider.getTransactionFee('Withdraw', alice.address(), 'RBTC');
         expect(fee).to.exist;
         const batchFee = await provider.getBatchFullFee(
             [
                 { txType: 'Transfer', address: alice.address() },
                 { txType: 'Withdraw', address: alice.address() }
             ],
-            'ETH'
+            'RBTC'
         );
         expect(batchFee).to.exist;
     });
@@ -235,8 +235,8 @@ describe('ZkSync REST API V0.2 tests', () => {
         expect(tokens.list[1]).to.be.eql(secondToken);
 
         // Case insensitivity check.
-        const ethToken1 = await provider.tokenInfo('ETH');
-        const ethToken2 = await provider.tokenInfo('eth');
+        const ethToken1 = await provider.tokenInfo('RBTC');
+        const ethToken2 = await provider.tokenInfo('rbtc');
         expect(tokens.list[0]).to.be.eql(ethToken1);
         expect(tokens.list[0]).to.be.eql(ethToken2);
 
@@ -258,9 +258,9 @@ describe('ZkSync REST API V0.2 tests', () => {
 
         const batch = await alice
             .batchBuilder()
-            .addTransfer({ to: bob.address(), token: 'ETH', amount: alice.provider.tokenSet.parseToken('ETH', '1') })
-            .addTransfer({ to: bob.address(), token: 'ETH', amount: alice.provider.tokenSet.parseToken('ETH', '1') })
-            .build('ETH');
+            .addTransfer({ to: bob.address(), token: 'RBTC', amount: alice.provider.tokenSet.parseToken('RBTC', '1') })
+            .addTransfer({ to: bob.address(), token: 'RBTC', amount: alice.provider.tokenSet.parseToken('RBTC', '1') })
+            .build('RBTC');
         const submitBatchResponse = await provider.submitTxsBatchNew(batch.txs, [batch.signature!]);
         await provider.notifyAnyTransaction(submitBatchResponse.transactionHashes[0], 'COMMIT');
         const batchInfo = await provider.getBatch(submitBatchResponse.batchHash);
@@ -277,7 +277,7 @@ describe('ZkSync web3 API tests', () => {
     let tester: Tester;
     let alice: Wallet;
     let bob: Wallet;
-    const token: string = 'ETH';
+    const token: string = 'RBTC';
     let depositAmount: ethers.BigNumber;
     let web3Provider: ethers.ethers.providers.BaseProvider;
     let restProvider: RestProvider;
@@ -323,7 +323,7 @@ describe('ZkSync web3 API tests', () => {
     });
 
     it('should check logs', async () => {
-        const fee = (await restProvider.getTransactionFee('Transfer', bob.address(), 'ETH')).totalFee;
+        const fee = (await restProvider.getTransactionFee('Transfer', bob.address(), 'RBTC')).totalFee;
         const transferAmount = depositAmount.div(10);
         const handle = await alice.syncTransfer({
             to: bob.address(),
@@ -405,7 +405,7 @@ describe('ZkSync web3 API tests', () => {
         const owner1 = nftFactoryContract.interface.decodeFunctionResult(ownerOfFunction, callResult)[0];
         expect(owner1, 'Incorrect owner after mint').to.eql(alice.address());
 
-        const transferHandle = (await alice.syncTransferNFT({ to: bob.address(), token: nft, feeToken: 'ETH' }))[0];
+        const transferHandle = (await alice.syncTransferNFT({ to: bob.address(), token: nft, feeToken: 'RBTC' }))[0];
         await transferHandle.awaitVerifyReceipt();
 
         callResult = await web3Provider.call({ to: nftFactoryAddress, data: ownerOfCallData });

--- a/core/tests/ts-tests/tests/suits/basic.ts
+++ b/core/tests/ts-tests/tests/suits/basic.ts
@@ -22,17 +22,17 @@ const TX_AMOUNT = utils.parseEther('10.0');
 // should be enough for ~200 test transactions (excluding fees), increase if needed
 const DEPOSIT_AMOUNT = TX_AMOUNT.mul(200);
 
-// wBTC is chosen because it has decimals different from ETH (8 instead of 18).
+// wBTC is chosen because it has decimals different from RBTC (8 instead of 18).
 // Using this token will help us to detect decimals-related errors.
 const defaultERC20 = 'wBTC';
 
-// We need to check that we can work with both ETH and ERC20 tokens, and both with RPC and REST APIs.
+// We need to check that we can work with both RBTC and ERC20 tokens, and both with RPC and REST APIs.
 // In order to cover the whole flow, three combinations are sufficient: if either of tokens or APIs
 // doesn't work as it supposed to, some test will fail.
 let tokenAndTransport = [
     {
         transport: 'HTTP',
-        token: 'ETH',
+        token: 'RBTC',
         providerType: 'RPC'
     },
     {
@@ -53,7 +53,7 @@ let tokenAndTransport = [
  * Basic test suite covers the, well, basic server functionality: availability of API, ability to execute transactions
  * and priority operations, etc.
  *
- * Since we have two main APIs (REST and RPC) and processing of ERC20 tokens and ETH differs, we run the same set of basic
+ * Since we have two main APIs (REST and RPC) and processing of ERC20 tokens and RBTC differs, we run the same set of basic
  * tests multiple times to cover APIs and tokens combinations.
  * Because of that the tests in the basic suite are expected to be fast, so running them three times won't become a burden.
  *

--- a/core/tests/ts-tests/tests/suits/extended.ts
+++ b/core/tests/ts-tests/tests/suits/extended.ts
@@ -35,7 +35,7 @@ describe(`Extended tests`, () => {
     const transport = 'HTTP';
     const providerType = 'REST';
     const token = 'wBTC';
-    const secondToken = 'ETH';
+    const secondToken = 'RBTC';
 
     let tester: Tester;
     let alice: Wallet;

--- a/core/tests/ts-tests/tests/suits/full-exit.ts
+++ b/core/tests/ts-tests/tests/suits/full-exit.ts
@@ -22,14 +22,14 @@ const TX_AMOUNT = utils.parseEther('10.0');
 // should be enough for ~200 test transactions (excluding fees), increase if needed
 const DEPOSIT_AMOUNT = TX_AMOUNT.mul(200);
 
-// wBTC is chosen because it has decimals different from ETH (8 instead of 18).
+// wBTC is chosen because it has decimals different from RBTC (8 instead of 18).
 // Using this token will help us to detect decimals-related errors.
 const defaultERC20 = 'wBTC';
 
 /**
  * Tests for the Full Exit priority operation.
  * These tests don't actually rely on the API, so they are not included into the basic suite,
- * but the processing of ERC20 tokens and ETH in server and contract is different, thus we run
+ * but the processing of ERC20 tokens and RBTC in server and contract is different, thus we run
  * these tests for both types of tokens.
  */
 const FullExitTestSuite = (token: types.TokenSymbol) =>
@@ -90,4 +90,4 @@ const FullExitTestSuite = (token: types.TokenSymbol) =>
     });
 
 FullExitTestSuite(defaultERC20);
-FullExitTestSuite('ETH');
+FullExitTestSuite('RBTC');

--- a/core/tests/ts-tests/tests/suits/no2fa.ts
+++ b/core/tests/ts-tests/tests/suits/no2fa.ts
@@ -29,7 +29,7 @@ describe(`No2FA tests`, () => {
     const transport = 'HTTP';
     const providerType = 'REST';
     const token = 'wBTC';
-    const secondToken = 'ETH';
+    const secondToken = 'RBTC';
 
     let tester: Tester;
     let hilda: Wallet;

--- a/core/tests/ts-tests/tests/tester/forced-exit-requests.ts
+++ b/core/tests/ts-tests/tests/tester/forced-exit-requests.ts
@@ -61,7 +61,7 @@ Tester.prototype.testForcedExitRequestMultipleTokens = async function (
             amount: amounts[i]
         });
     });
-    const batch = await batchBuilder.build('ETH');
+    const batch = await batchBuilder.build('RBTC');
     const handles = await wallet.submitSignedTransactionsBatch(from.provider, batch.txs, [batch.signature!]);
 
     // Waiting only for the first tx since we send the transactions in batch

--- a/core/tests/ts-tests/tests/tester/withdrawal-helpers.ts
+++ b/core/tests/ts-tests/tests/tester/withdrawal-helpers.ts
@@ -14,7 +14,7 @@ type TokenLike = types.TokenLike;
 
 declare module './tester' {
     interface Tester {
-        testRecoverETHWithdrawal(from: Wallet, to: Address, amount: BigNumber): Promise<void>;
+        testRecoverRBTCWithdrawal(from: Wallet, to: Address, amount: BigNumber): Promise<void>;
         testRecoverERC20Withdrawal(from: Wallet, to: Address, token: TokenLike, amount: BigNumber): Promise<void>;
         testRecoverMultipleWithdrawals(
             from: Wallet,
@@ -68,20 +68,20 @@ async function setRevert(
     const tokenSymbol = provider.tokenSet.resolveTokenSymbol(token);
     const tokenAddress = provider.tokenSet.resolveTokenAddress(token);
 
-    if (tokenSymbol === 'ETH') {
+    if (tokenSymbol === 'RBTC') {
         await setRevertReceive(ethWallet, recipient, value);
     } else {
         await setRevertTransfer(ethWallet, tokenAddress, value);
     }
 }
 
-Tester.prototype.testRecoverETHWithdrawal = async function (from: Wallet, to: Address, amount: BigNumber) {
+Tester.prototype.testRecoverRBTCWithdrawal = async function (from: Wallet, to: Address, amount: BigNumber) {
     // Make sure that the withdrawal will fail
-    await setRevert(from.ethSigner(), this.syncProvider, to, 'ETH', true);
+    await setRevert(from.ethSigner(), this.syncProvider, to, 'RBTC', true);
     const balanceBefore = await this.ethProvider.getBalance(to);
     const withdrawTx = await from.withdrawFromSyncToEthereum({
         ethAddress: to,
-        token: 'ETH',
+        token: 'RBTC',
         amount
     });
     await withdrawTx.awaitVerifyReceipt();
@@ -96,10 +96,10 @@ Tester.prototype.testRecoverETHWithdrawal = async function (from: Wallet, to: Ad
     expect(balanceBefore.eq(balanceAfter), 'The withdrawal did not fail the first time').to.be.true;
 
     // Make sure that the withdrawal will pass now
-    await setRevert(from.ethSigner(), this.syncProvider, to, 'ETH', false);
+    await setRevert(from.ethSigner(), this.syncProvider, to, 'RBTC', false);
 
     // Re-try
-    const withdrawPendingTx = await from.withdrawPendingBalance(to, 'ETH');
+    const withdrawPendingTx = await from.withdrawPendingBalance(to, 'RBTC');
     await withdrawPendingTx.wait();
 
     // The funds should have arrived

--- a/core/tests/ts-tests/tests/withdrawal-helpers.test.ts
+++ b/core/tests/ts-tests/tests/withdrawal-helpers.test.ts
@@ -30,7 +30,7 @@ const TestSuite = (providerType: 'REST' | 'RPC') =>
             bob = await tester.fundedWallet('10.0');
             chuck = await tester.emptyWallet();
 
-            for (const token of ['ETH', erc20Token]) {
+            for (const token of ['RBTC', erc20Token]) {
                 await tester.testDeposit(alice, token, DEPOSIT_AMOUNT, true);
                 await tester.testChangePubKey(alice, token, false);
             }
@@ -43,8 +43,8 @@ const TestSuite = (providerType: 'REST' | 'RPC') =>
             await tester.disconnect();
         });
 
-        it('should recover failed ETH withdraw', async () => {
-            await tester.testRecoverETHWithdrawal(alice, TEST_CONFIG.withdrawalHelpers.revert_receive_address, TX_AMOUNT);
+        it('should recover failed RBTC withdraw', async () => {
+            await tester.testRecoverRBTCWithdrawal(alice, TEST_CONFIG.withdrawalHelpers.revert_receive_address, TX_AMOUNT);
         });
 
         it('should recover failed ERC20 withdraw', async () => {
@@ -63,7 +63,7 @@ const TestSuite = (providerType: 'REST' | 'RPC') =>
                     TEST_CONFIG.withdrawalHelpers.revert_receive_address,
                     TEST_CONFIG.withdrawalHelpers.revert_receive_address
                 ],
-                ['ETH', erc20Token],
+                ['RBTC', erc20Token],
                 [TX_AMOUNT, TX_AMOUNT]
             );
         });
@@ -73,7 +73,7 @@ const TestSuite = (providerType: 'REST' | 'RPC') =>
                 alice,
                 bob.ethSigner(),
                 chuck.address(),
-                ['ETH', erc20Token],
+                ['RBTC', erc20Token],
                 [TX_AMOUNT, TX_AMOUNT.mul(2)]
             );
         });

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -25,7 +25,7 @@ To enforece censorship-resistance and enable guaranteed retrievability of the fu
 
 To make deposit, a user can:
 
-- Either send ETH to smart contract (will be handled by the default function),
+- Either send RBTC to smart contract (will be handled by the default function),
 - or call `depositERC20()` function to perform transferFrom for a registered ERC20 token. Note: the user must have
   previously called approve() on the ERC20 token contract in order to authorize ZKSync contract to perform this
   operation.
@@ -56,7 +56,7 @@ operation** are acrued to the users' **root-chain balances**.
 
 If the block is reverted, this **withdraw onchain operations** are simply discarded.
 
-A user can withdraw funds from the **root-chain balance** at any time by calling a `withdrawETH()` or `withdrawERC20()`
+A user can withdraw funds from the **root-chain balance** at any time by calling a `withdrawRBTC()` or `withdrawERC20()`
 function.
 
 ### Full exit

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -66,7 +66,7 @@
 
 ### Overview
 
-zkSync implements a ZK rollup protocol (in short "rollup" below) for ETH and ERC20 fungible token transfers.
+zkSync implements a ZK rollup protocol (in short "rollup" below) for RBTC and ERC20 fungible token transfers.
 
 General rollup workflow is as follows:
 
@@ -288,8 +288,8 @@ Account.address -> EthAddress # Address of the account
 Account.pubkey_hash -> RollupPubkeyHash # Hash of the public key set for the account
 
 # Constants
-MAX_TOKENS = 2**32 # maximum number of tokens in the Rollup(including "ETH" token)
-MAX_FUNGIBLE_TOKENS = 2**16 # maximum number of fungible tokens in the Rollup(including "ETH" token)
+MAX_TOKENS = 2**32 # maximum number of tokens in the Rollup(including "RBTC" token)
+MAX_FUNGIBLE_TOKENS = 2**16 # maximum number of fungible tokens in the Rollup(including "RBTC" token)
 MAX_NONCE = 2**32 # max possible nonce
 ```
 
@@ -1772,7 +1772,7 @@ def pubdata_invariants():
 Deposit Ether to Rollup - transfer Ether from user L1 address into Rollup address
 
 ```solidity
-function depositETH(address _zkSyncAddress) payable
+function depositRBTC(address _zkSyncAddress) payable
 ```
 
 - `_zkSyncAddress`: The receiver Layer 2 address

--- a/etc/env/base/misc.toml
+++ b/etc/env/base/misc.toml
@@ -21,7 +21,7 @@ max_liquidation_fee_percent=5
 
 reserve_fee_accumulator_address="unset"
 
-established_assets_for_withdrawing_through_zksync="ETH,DAI,USDC"
+established_assets_for_withdrawing_through_zksync="RBTC,DAI,USDC"
 
 # Format of logs in stdout could be "plain" for development purposes and "json" for production
 log_format="plain"

--- a/etc/env/mainnet/misc.toml
+++ b/etc/env/mainnet/misc.toml
@@ -21,7 +21,7 @@ max_liquidation_fee_percent=5
 
 reserve_fee_accumulator_address="unset"
 
-established_assets_for_withdrawing_through_zksync="ETH,DAI,USDC"
+established_assets_for_withdrawing_through_zksync="RBTC,DAI,USDC"
 
 # Format of logs in stdout could be "plain" for development purposes and "json" for production
 log_format="plain"

--- a/etc/env/testnet/misc.toml
+++ b/etc/env/testnet/misc.toml
@@ -21,7 +21,7 @@ max_liquidation_fee_percent=5
 
 reserve_fee_accumulator_address="unset"
 
-established_assets_for_withdrawing_through_zksync="ETH,DAI,USDC"
+established_assets_for_withdrawing_through_zksync="RBTC,DAI,USDC"
 
 # Format of logs in stdout could be "plain" for development purposes and "json" for production
 log_format="plain"

--- a/etc/env/zk_original_configuration/forced_exit_requests.toml
+++ b/etc/env/zk_original_configuration/forced_exit_requests.toml
@@ -16,7 +16,7 @@ tx_interval_scaling_factor=1.5
 # Number of digits in id
 digits_in_id=13
 
-# Price per exit in wei (currently it's 0.03 ETH)
+# Price per exit in wei (currently it's 0.03 RBTC) TODO: true in RSK? 
 price_per_token=30000000000000000
 
 # Wait confirmations
@@ -28,7 +28,7 @@ sender_account_address="0xe1faB3eFD74A77C23B426c302D96372140FF7d0C"
 # The time after which an invalid request is deleted in milliseconds
 expiration_period=3000
 
-# The minimum amount of ETH in wei that needs to be stored on the forced exit smart contract 
+# The minimum amount of RBTC in wei that needs to be stored on the forced exit smart contract 
 # until it is ok to withdraw the funds from it
 withdrawal_threshold=1000000000000000000
 

--- a/etc/env/zk_original_configuration/misc.toml
+++ b/etc/env/zk_original_configuration/misc.toml
@@ -21,7 +21,7 @@ max_liquidation_fee_percent=5
 
 reserve_fee_accumulator_address="unset"
 
-established_assets_for_withdrawing_through_zksync="ETH,DAI,USDC"
+established_assets_for_withdrawing_through_zksync="RBTC,DAI,USDC"
 
 # Format of logs in stdout could be "plain" for development purposes and "json" for production
 log_format="plain"

--- a/etc/test_config/sdk/test-vectors.json
+++ b/etc/test_config/sdk/test-vectors.json
@@ -35,7 +35,7 @@
           },
           "ethSignData": {
             "stringAmount": "1000000000000.0",
-            "stringToken": "ETH",
+            "stringToken": "RBTC",
             "stringFee": "1000000.0",
             "to": "0x19aa2ed8712072e918632259780e587698ef58df",
             "accountId": 44,
@@ -102,7 +102,7 @@
           },
           "ethSignData": {
             "stringAmount": "1000000000000.0",
-            "stringToken": "ETH",
+            "stringToken": "RBTC",
             "stringFee": "1000000.0",
             "ethAddress": "0x19aa2ed8712072e918632259780e587698ef58df",
             "accountId": 44,
@@ -159,7 +159,7 @@
             "nonce": 12
           },
           "ethSignData": {
-            "stringFeeToken": "ETH",
+            "stringFeeToken": "RBTC",
             "stringFee": "1000000.0",
             "recipient": "0x19aa2ed8712072e918632259780e587698ef58df",
             "contentHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
@@ -195,7 +195,7 @@
             "token": 100000,
             "to": "0x19aa2ed8712072e918632259780e587698ef58df",
             "stringFee": "1000000.0",
-            "stringFeeToken": "ETH",
+            "stringFeeToken": "RBTC",
             "nonce": 12
           }
         },
@@ -228,7 +228,7 @@
             "validUntil": 4294967295
           },
           "ethSignData": {
-            "tokenSell": "ETH",
+            "tokenSell": "RBTC",
             "tokenBuy": "DAI",
             "recipient": "0x823b6a996cea19e0c41e250b20e2e804ea72ccdf",
             "amount": "1000.0",
@@ -479,12 +479,12 @@
         },
         {
           "inputs": {
-            "token": "ETH",
+            "token": "RBTC",
             "decimals": 18,
             "amount": "1000000000000000100000"
           },
           "outputs": {
-            "formatted": "1000.0000000000001 ETH"
+            "formatted": "1000.0000000000001 RBTC"
           }
         }
       ]

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,7 +1,7 @@
 # zkSync infrastructure
 
 **zkSync** is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of
-ETH and ERC20 tokens in the Rootstock network.
+RBTC and ERC20 tokens in the Rootstock network.
 
 This document is a description of the supplementary infrastructure of the project.
 

--- a/infrastructure/api-docs/blueprint/groups/fee.apib
+++ b/infrastructure/api-docs/blueprint/groups/fee.apib
@@ -9,7 +9,7 @@ Request fee for a single transaction.
     + Attributes
         + txType: Transfer (Fee.Type, required)
         + address: 0xf33A2D61DD09541A8C9897D7236aDcCCC14Cf769 (string, required)
-        + tokenLike: ETH (Token.TokenLike, required)
+        + tokenLike: RBTC (Token.TokenLike, required)
 
 + Response 200 (application/json)
     + Attributes
@@ -26,7 +26,7 @@ Request fee for a transactions batch.
 + Request (application/json)
     + Attributes
         + transactions (array[Fee.Type.with.Address], required)
-        + tokenLike: ETH (Token.TokenLike, required)
+        + tokenLike: RBTC (Token.TokenLike, required)
 
 + Response 200 (application/json)
     + Attributes

--- a/infrastructure/api-docs/blueprint/types/accounts.apib
+++ b/infrastructure/api-docs/blueprint/types/accounts.apib
@@ -22,14 +22,14 @@
 + balances (DepositingBalances, required)
 
 ## DepositingBalances (object)
-+ *ETH* (DepositingFunds, required)
++ *RBTC* (DepositingFunds, required)
 
 ## DepositingFunds (object)
 + amount: `1000000000000000000` (string, required)
 + expectedAcceptBlock: 25136211 (number, required)
 
 ## Account.Balances (object)
-+ *ETH*: `1000000000000000000` (string, required)
++ *RBTC*: `1000000000000000000` (string, required)
 
 ## Account.Nfts (object)
 + *100000* (Token.NFT, required)

--- a/infrastructure/api-docs/src/compile.ts
+++ b/infrastructure/api-docs/src/compile.ts
@@ -56,14 +56,14 @@ async function setupWallet() {
 
     const depositHandle = await syncWallet.depositToSyncFromEthereum({
         depositTo: syncWallet.address(),
-        token: 'ETH',
-        amount: syncWallet.provider.tokenSet.parseToken('ETH', '1000')
+        token: 'RBTC',
+        amount: syncWallet.provider.tokenSet.parseToken('RBTC', '1000')
     });
     await depositHandle.awaitReceipt();
 
     if (!(await syncWallet.isSigningKeySet())) {
         const changePubkeyHandle = await syncWallet.setSigningKey({
-            feeToken: 'ETH',
+            feeToken: 'RBTC',
             ethAuthType: 'ECDSA'
         });
         await changePubkeyHandle.awaitReceipt();
@@ -90,14 +90,14 @@ interface Parameters {
 async function getHashesAndSignatures() {
     let syncWallet = await setupWallet();
 
-    const handle = await syncWallet.syncTransfer({ to: syncWallet.address(), token: 'ETH', amount: 0 });
+    const handle = await syncWallet.syncTransfer({ to: syncWallet.address(), token: 'RBTC', amount: 0 });
     await handle.awaitReceipt();
     const txHash = handle.txHash;
 
     const batch = await syncWallet
         .batchBuilder()
-        .addTransfer({ to: syncWallet.address(), token: 'ETH', amount: 0 })
-        .build('ETH');
+        .addTransfer({ to: syncWallet.address(), token: 'RBTC', amount: 0 })
+        .build('RBTC');
 
     const submitBatchResponse = await (syncWallet.provider as zksync.RestProvider).submitTxsBatchNew(
         batch.txs,
@@ -108,7 +108,7 @@ async function getHashesAndSignatures() {
 
     const signedTransfer = await syncWallet.signSyncTransfer({
         to: '0xD3c62D2F7b6d4A63577F2415E55A6Aa6E1DbB9CA',
-        token: 'ETH',
+        token: 'RBTC',
         amount: '17500000000000000',
         fee: '12000000000000000000',
         nonce: 12123,
@@ -124,7 +124,7 @@ async function getHashesAndSignatures() {
     const mintHandle = await syncWallet.mintNFT({
         recipient: address,
         contentHash: ethers.utils.randomBytes(32),
-        feeToken: 'ETH'
+        feeToken: 'RBTC'
     });
     const mintNFTTxHash = mintHandle.txHash;
     await mintHandle.awaitVerifyReceipt();

--- a/infrastructure/zk/src/server.ts
+++ b/infrastructure/zk/src/server.ts
@@ -86,7 +86,7 @@ async function prepareForcedExitRequestAccount() {
         ethRichWallet
     );
 
-    const depositTransaction = (await mainZkSyncContract.depositETH(forcedExitAccount, {
+    const depositTransaction = (await mainZkSyncContract.depositRBTC(forcedExitAccount, {
         // Here the amount to deposit does not really matter, as it is done purely
         // to guarantee that the account exists in the network
         value: ethers.utils.parseEther('1.0'),

--- a/sdk/zksync-rs/README.md
+++ b/sdk/zksync-rs/README.md
@@ -1,7 +1,7 @@
 # Rust SDK for zkSync
 
 **zkSync** is a scaling and privacy engine for Rootstock. Its current functionality scope includes low gas transfers of
-ETH and ERC20 tokens in the Rootstock network.
+RBTC and ERC20 tokens in the Rootstock network.
 
 This document is a description of the Rust library that can be used to interact with zkSync.
 

--- a/sdk/zksync-rs/src/rootstock/abi/ZkSync.json
+++ b/sdk/zksync-rs/src/rootstock/abi/ZkSync.json
@@ -455,7 +455,7 @@
           "type": "address"
         }
       ],
-      "name": "depositETH",
+      "name": "depositRBTC",
       "outputs": [],
       "stateMutability": "payable",
       "type": "function"

--- a/sdk/zksync-rs/src/rootstock/mod.rs
+++ b/sdk/zksync-rs/src/rootstock/mod.rs
@@ -115,7 +115,7 @@ impl<S: EthereumSigner> RootstockProvider<S> {
     /// Returns the Rootstock account balance.
     pub async fn balance(&self) -> Result<BigUint, ClientError> {
         self.client()
-            .sender_eth_balance()
+            .sender_rbtc_balance()
             .await
             .map_err(|err| ClientError::NetworkError(err.to_string()))
             .map(u256_to_biguint)
@@ -253,7 +253,7 @@ impl<S: EthereumSigner> RootstockProvider<S> {
             .resolve(token.clone())
             .ok_or(ClientError::UnknownToken)?;
 
-        let signed_tx = if self.tokens_cache.is_eth(token) {
+        let signed_tx = if self.tokens_cache.is_rbtc(token) {
             let options = Options {
                 value: Some(amount),
                 gas: Some(300_000.into()),
@@ -308,8 +308,8 @@ impl<S: EthereumSigner> RootstockProvider<S> {
             .resolve(token.clone())
             .ok_or(ClientError::UnknownToken)?;
 
-        if self.tokens_cache.is_eth(token) {
-            // ETH minting is not supported
+        if self.tokens_cache.is_rbtc(token) {
+            // RBTC minting is not supported
             return Err(ClientError::IncorrectInput);
         }
 
@@ -359,13 +359,13 @@ impl<S: EthereumSigner> RootstockProvider<S> {
             .resolve(token.clone())
             .ok_or(ClientError::UnknownToken)?;
 
-        let signed_tx = if self.tokens_cache.is_eth(token) {
+        let signed_tx = if self.tokens_cache.is_rbtc(token) {
             let options = Options {
                 value: Some(amount),
                 gas: Some(200_000.into()),
                 ..Default::default()
             };
-            let data = self.client().encode_tx_data("depositETH", sync_address);
+            let data = self.client().encode_tx_data("depositRBTC", sync_address);
 
             self.client()
                 .sign_prepared_tx(data, options)

--- a/sdk/zksync-rs/src/tokens_cache.rs
+++ b/sdk/zksync-rs/src/tokens_cache.rs
@@ -23,7 +23,7 @@ impl TokensCache {
         }
     }
 
-    pub fn is_eth(&self, token: TokenLike) -> bool {
-        token.is_eth()
+    pub fn is_rbtc(&self, token: TokenLike) -> bool {
+        token.is_rbtc()
     }
 }

--- a/sdk/zksync-rs/tests/integration.rs
+++ b/sdk/zksync-rs/tests/integration.rs
@@ -83,10 +83,10 @@ async fn get_ethereum_balance<S: EthereumSigner>(
     address: Address,
     token: &Token,
 ) -> Result<U256, anyhow::Error> {
-    if token.symbol == "ETH" {
+    if token.symbol == "RBTC" {
         return eth_provider
             .client()
-            .eth_balance(address)
+            .rbtc_balance(address)
             .await
             .map_err(|_e| anyhow::anyhow!("failed to request balance from Rootstock {}", _e));
     }
@@ -175,7 +175,7 @@ where
     let handle = sync_wallet
         .start_transfer()
         .to(zksync_depositor_wallet.address())
-        .token("ETH")?
+        .token("RBTC")?
         .amount(1_000_000u64)
         .send()
         .await;
@@ -201,7 +201,7 @@ where
 {
     let rootstock = deposit_wallet.rootstock(web3_addr()).await?;
 
-    if !deposit_wallet.tokens.is_eth(token.address.into()) {
+    if !deposit_wallet.tokens.is_rbtc(token.address.into()) {
         if !rootstock.is_erc20_deposit_approved(token.address).await? {
             let tx_approve_deposits = rootstock
                 .limited_approve_erc20_token_deposits(token.address, U256::from(amount))
@@ -228,7 +228,7 @@ where
     rootstock.wait_for_tx(deposit_tx_hash).await?;
     wait_for_deposit_and_update_account_id(sync_wallet).await;
 
-    if !sync_wallet.tokens.is_eth(token.address.into()) {
+    if !sync_wallet.tokens.is_rbtc(token.address.into()) {
         // It should not be approved because we have approved only DEPOSIT_AMOUNT, not the maximum possible amount of deposit
         assert!(
             !rootstock
@@ -509,7 +509,7 @@ where
     println!("Withdraw ok, Token: {}", token.symbol);
 
     // Currently fast withdraw aren't supported by zksync-rs, but they will be in the near future.
-    // test_fast_withdraw(eth, main_contract, &bob, &bob, &token, withdraw_amount);
+    // test_fast_withdraw(rbtc, main_contract, &bob, &bob, &token, withdraw_amount);
     // println!("Fast withdraw ok, Token: {}", token.symbol);
 
     // Currently multi transactions aren't supported by zksync-rs, but they will be in the near future.
@@ -526,7 +526,7 @@ async fn init_account_with_one_ether(
 
     // Transfer funds from "rich" account to a randomly created one (so we won't reuse the same
     // account in subsequent test runs).
-    transfer_to("ETH", one_ether(), eth_address).await?;
+    transfer_to("RBTC", one_ether(), eth_address).await?;
 
     let provider = RpcProvider::new(Network::Localhost);
 
@@ -540,7 +540,7 @@ async fn init_account_with_one_ether(
     let rootstock = wallet.rootstock(web3_addr()).await?;
 
     let deposit_tx_hash = rootstock
-        .deposit("ETH", one_ether() / 2, wallet.address())
+        .deposit("RBTC", one_ether() / 2, wallet.address())
         .await?;
 
     rootstock.wait_for_tx(deposit_tx_hash).await?;
@@ -551,7 +551,7 @@ async fn init_account_with_one_ether(
     if !wallet.is_signing_key_set().await? {
         let handle = wallet
             .start_change_pubkey()
-            .fee_token("ETH")?
+            .fee_token("RBTC")?
             .send()
             .await?;
 
@@ -600,9 +600,9 @@ async fn comprehensive_test() -> Result<(), anyhow::Error> {
             .main_contract_with_address(contract_address)
     };
 
-    let token_eth = sync_depositor_wallet
+    let token_rbtc = sync_depositor_wallet
         .tokens
-        .resolve("ETH".into())
+        .resolve("RBTC".into())
         .ok_or_else(|| anyhow::anyhow!("Error resolve token"))?;
     let token_dai = sync_depositor_wallet
         .tokens
@@ -611,16 +611,16 @@ async fn comprehensive_test() -> Result<(), anyhow::Error> {
 
     let dai_deposit_amount = U256::from(10).pow(18.into()) * 10000; // 10000 DAI
 
-    // Move ETH to wallets so they will have some funds for L1 transactions.
-    let eth_deposit_amount = U256::from(10).pow(17.into()); // 0.1 ETH
-    transfer_to("ETH", eth_deposit_amount, sync_depositor_wallet.address()).await?;
-    transfer_to("ETH", eth_deposit_amount, alice_wallet1.address()).await?;
-    transfer_to("ETH", eth_deposit_amount, bob_wallet1.address()).await?;
+    // Move RBTC to wallets so they will have some funds for L1 transactions.
+    let eth_deposit_amount = U256::from(10).pow(17.into()); // 0.1 RBTC
+    transfer_to("RBTC", eth_deposit_amount, sync_depositor_wallet.address()).await?;
+    transfer_to("RBTC", eth_deposit_amount, alice_wallet1.address()).await?;
+    transfer_to("RBTC", eth_deposit_amount, bob_wallet1.address()).await?;
 
     transfer_to("DAI", dai_deposit_amount, sync_depositor_wallet.address()).await?;
 
     assert_eq!(
-        get_ethereum_balance(&rootstock, sync_depositor_wallet.address(), &token_eth).await?,
+        get_ethereum_balance(&rootstock, sync_depositor_wallet.address(), &token_rbtc).await?,
         eth_deposit_amount
     );
     assert_eq!(
@@ -654,7 +654,7 @@ async fn simple_transfer() -> Result<(), anyhow::Error> {
     let handle = wallet
         .start_transfer()
         .to(wallet.signer.address)
-        .token("ETH")?
+        .token("RBTC")?
         .amount(1_000_000u64)
         .send()
         .await?;
@@ -673,13 +673,13 @@ async fn nft_test() -> Result<(), anyhow::Error> {
     let alice = init_account_with_one_ether().await?;
     let bob = init_account_with_one_ether().await?;
 
-    let alice_balance_before = alice.get_balance(BlockStatus::Committed, "ETH").await?;
-    let bob_balance_before = bob.get_balance(BlockStatus::Committed, "ETH").await?;
+    let alice_balance_before = alice.get_balance(BlockStatus::Committed, "RBTC").await?;
+    let bob_balance_before = bob.get_balance(BlockStatus::Committed, "RBTC").await?;
 
     // Perform a mint nft transaction.
     let fee = alice
         .provider
-        .get_tx_fee(TxFeeTypes::MintNFT, alice.address(), "ETH")
+        .get_tx_fee(TxFeeTypes::MintNFT, alice.address(), "RBTC")
         .await?
         .total_fee;
 
@@ -687,7 +687,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
         .start_mint_nft()
         .recipient(alice.signer.address)
         .content_hash(H256::zero())
-        .fee_token("ETH")?
+        .fee_token("RBTC")?
         .fee(fee.clone())
         .send()
         .await?;
@@ -706,7 +706,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
         .last()
         .expect("NFT was not minted")
         .clone();
-    let alice_balance_after_mint = alice.get_balance(BlockStatus::Committed, "ETH").await?;
+    let alice_balance_after_mint = alice.get_balance(BlockStatus::Committed, "RBTC").await?;
     assert_eq!(fee + alice_balance_after_mint.clone(), alice_balance_before);
 
     // Perform a transfer nft transaction.
@@ -715,14 +715,14 @@ async fn nft_test() -> Result<(), anyhow::Error> {
         .get_txs_batch_fee(
             vec![TxFeeTypes::Transfer, TxFeeTypes::Transfer],
             vec![bob.address(), bob.address()],
-            "ETH",
+            "RBTC",
         )
         .await?;
     let handles = alice
         .start_transfer_nft()
         .to(bob.signer.address)
         .nft(nft.clone())
-        .fee_token("ETH")?
+        .fee_token("RBTC")?
         .fee(fee.clone())
         .send()
         .await?;
@@ -734,7 +734,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
             .await?;
     }
 
-    let alice_balance_after_transfer = alice.get_balance(BlockStatus::Committed, "ETH").await?;
+    let alice_balance_after_transfer = alice.get_balance(BlockStatus::Committed, "RBTC").await?;
     let alice_nft_balance = alice.get_nft(BlockStatus::Committed, nft.id).await?;
     let bob_nft_balance = bob.get_nft(BlockStatus::Committed, nft.id).await?;
     assert_eq!(fee + alice_balance_after_transfer, alice_balance_after_mint);
@@ -744,7 +744,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
     //Perform a withdraw nft transaction.
     let fee = alice
         .provider
-        .get_tx_fee(TxFeeTypes::WithdrawNFT, bob.address(), "ETH")
+        .get_tx_fee(TxFeeTypes::WithdrawNFT, bob.address(), "RBTC")
         .await?
         .total_fee;
 
@@ -752,7 +752,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
         .start_withdraw_nft()
         .to(bob.signer.address)
         .token(nft.id)?
-        .fee_token("ETH")?
+        .fee_token("RBTC")?
         .fee(fee.clone())
         .send()
         .await?;
@@ -761,7 +761,7 @@ async fn nft_test() -> Result<(), anyhow::Error> {
         .commit_timeout(Duration::from_secs(180))
         .wait_for_commit()
         .await?;
-    let bob_balance_after_withdraw = bob.get_balance(BlockStatus::Committed, "ETH").await?;
+    let bob_balance_after_withdraw = bob.get_balance(BlockStatus::Committed, "RBTC").await?;
     let bob_nft_balance = bob.get_nft(BlockStatus::Committed, nft.id).await?;
     assert_eq!(fee + bob_balance_after_withdraw, bob_balance_before);
     assert!(bob_nft_balance.is_none());
@@ -780,7 +780,7 @@ async fn full_exit_test() -> Result<(), anyhow::Error> {
         .start_mint_nft()
         .recipient(wallet.signer.address)
         .content_hash(H256::zero())
-        .fee_token("ETH")?
+        .fee_token("RBTC")?
         .send()
         .await?;
 
@@ -789,9 +789,9 @@ async fn full_exit_test() -> Result<(), anyhow::Error> {
         .wait_for_verify()
         .await?;
 
-    // ETH full exit
+    // RBTC full exit
     let full_exit_tx_hash = rootstock
-        .full_exit("ETH", wallet.account_id().unwrap())
+        .full_exit("RBTC", wallet.account_id().unwrap())
         .await?;
     let receipt = rootstock.wait_for_tx(full_exit_tx_hash).await?;
     let mut serial_id = None;
@@ -806,7 +806,7 @@ async fn full_exit_test() -> Result<(), anyhow::Error> {
         .wait_for_commit()
         .await?;
 
-    let balance = wallet.get_balance(BlockStatus::Committed, "ETH").await?;
+    let balance = wallet.get_balance(BlockStatus::Committed, "RBTC").await?;
     assert!(balance.is_zero());
 
     // NFT full exit
@@ -849,11 +849,11 @@ async fn batch_transfer() -> Result<(), anyhow::Error> {
     const RECIPIENT_COUNT: usize = 4;
     let recipients = vec![eth_random_account_credentials().0; RECIPIENT_COUNT];
 
-    let token_like = TokenLike::Symbol("ETH".to_owned());
+    let token_like = TokenLike::Symbol("RBTC".to_owned());
     let token = wallet
         .tokens
         .resolve(token_like.clone())
-        .expect("ETH token resolving failed");
+        .expect("RBTC token resolving failed");
 
     let mut nonce = wallet.account_info().await?.committed.nonce;
 

--- a/sdk/zksync-rs/tests/unit.rs
+++ b/sdk/zksync-rs/tests/unit.rs
@@ -8,8 +8,8 @@ use zksync_types::{tx::TxSignature, AccountId, Nonce, Token, TokenId, TokenKind}
 fn test_tokens_cache() {
     let mut tokens: HashMap<String, Token> = HashMap::default();
 
-    let token_eth = Token::new(TokenId(0), H160::default(), "ETH", 18, TokenKind::ERC20);
-    tokens.insert("ETH".to_string(), token_eth.clone());
+    let token_rbtc = Token::new(TokenId(0), H160::default(), "RBTC", 18, TokenKind::ERC20);
+    tokens.insert("RBTC".to_string(), token_rbtc.clone());
     let token_dai = Token::new(TokenId(1), H160::random(), "RDOC", 18, TokenKind::ERC20);
     tokens.insert("RDOC".to_string(), token_dai.clone());
 
@@ -18,16 +18,16 @@ fn test_tokens_cache() {
     let tokens_cache = TokensCache::new(tokens);
 
     assert_eq!(
-        tokens_cache.resolve(token_eth.address.into()),
-        Some(token_eth.clone())
+        tokens_cache.resolve(token_rbtc.address.into()),
+        Some(token_rbtc.clone())
     );
     assert_eq!(
-        tokens_cache.resolve(token_eth.id.into()),
-        Some(token_eth.clone())
+        tokens_cache.resolve(token_rbtc.id.into()),
+        Some(token_rbtc.clone())
     );
     assert_eq!(
-        tokens_cache.resolve((&token_eth.symbol as &str).into()),
-        Some(token_eth.clone())
+        tokens_cache.resolve((&token_rbtc.symbol as &str).into()),
+        Some(token_rbtc.clone())
     );
 
     assert_eq!(
@@ -50,13 +50,13 @@ fn test_tokens_cache() {
         None
     );
 
-    assert!(tokens_cache.is_eth(token_eth.address.into()));
-    assert!(tokens_cache.is_eth(token_eth.id.into()));
-    assert!(tokens_cache.is_eth((&token_eth.symbol as &str).into()));
+    assert!(tokens_cache.is_rbtc(token_rbtc.address.into()));
+    assert!(tokens_cache.is_rbtc(token_rbtc.id.into()));
+    assert!(tokens_cache.is_rbtc((&token_rbtc.symbol as &str).into()));
 
-    assert!(!tokens_cache.is_eth(token_dai.address.into()));
-    assert!(!tokens_cache.is_eth(token_dai.id.into()));
-    assert!(!tokens_cache.is_eth((&token_dai.symbol as &str).into()));
+    assert!(!tokens_cache.is_rbtc(token_dai.address.into()));
+    assert!(!tokens_cache.is_rbtc(token_dai.id.into()));
+    assert!(!tokens_cache.is_rbtc((&token_dai.symbol as &str).into()));
 }
 
 fn priv_key_from_raw(raw: &[u8]) -> Option<PrivateKey> {
@@ -735,7 +735,7 @@ mod wallet_tests {
     #[tokio::test]
     async fn test_wallet_get_balance_committed_not_existent() {
         let wallet = get_test_wallet(&[40; 32], Network::Mainnet).await;
-        let result = wallet.get_balance(BlockStatus::Committed, "ETH").await;
+        let result = wallet.get_balance(BlockStatus::Committed, "RBTC").await;
 
         assert_eq!(result.unwrap_err(), ClientError::UnknownToken);
     }
@@ -753,7 +753,7 @@ mod wallet_tests {
     #[tokio::test]
     async fn test_wallet_get_balance_verified_not_existent() {
         let wallet = get_test_wallet(&[50; 32], Network::Mainnet).await;
-        let result = wallet.get_balance(BlockStatus::Verified, "ETH").await;
+        let result = wallet.get_balance(BlockStatus::Verified, "RBTC").await;
 
         assert_eq!(result.unwrap_err(), ClientError::UnknownToken);
     }

--- a/sdk/zksync.js/abi/SyncMain.json
+++ b/sdk/zksync.js/abi/SyncMain.json
@@ -472,7 +472,7 @@
           "type": "address"
         }
       ],
-      "name": "depositETH",
+      "name": "depositRBTC",
       "outputs": [],
       "stateMutability": "payable",
       "type": "function"

--- a/sdk/zksync.js/src/abstract-wallet.ts
+++ b/sdk/zksync.js/src/abstract-wallet.ts
@@ -23,10 +23,10 @@ import {
     ERC20_APPROVE_TRESHOLD,
     ERC20_DEPOSIT_GAS_LIMIT,
     ERC20_RECOMMENDED_DEPOSIT_GAS_LIMIT,
-    ETH_RECOMMENDED_DEPOSIT_GAS_LIMIT,
+    RBTC_RECOMMENDED_DEPOSIT_GAS_LIMIT,
     getEthereumBalance,
     IERC20_INTERFACE,
-    isTokenETH,
+    isTokenRBTC,
     MAX_ERC20_APPROVE_AMOUNT,
     SYNC_MAIN_CONTRACT_INTERFACE,
     getToggle2FAMessage
@@ -440,8 +440,8 @@ export abstract class AbstractWallet {
         token: TokenLike,
         max_erc20_approve_amount: BigNumber = MAX_ERC20_APPROVE_AMOUNT
     ): Promise<ContractTransaction> {
-        if (isTokenETH(token)) {
-            throw Error('ETH token does not need approval.');
+        if (isTokenRBTC(token)) {
+            throw Error('RBTC token does not need approval.');
         }
         const tokenAddress = this.provider.tokenSet.resolveTokenAddress(token);
         const erc20contract = new Contract(tokenAddress, IERC20_INTERFACE, this.ethSigner());
@@ -466,11 +466,11 @@ export abstract class AbstractWallet {
 
         let ethTransaction;
 
-        if (isTokenETH(deposit.token)) {
+        if (isTokenRBTC(deposit.token)) {
             try {
-                ethTransaction = await mainZkSyncContract.depositETH(deposit.depositTo, {
+                ethTransaction = await mainZkSyncContract.depositRBTC(deposit.depositTo, {
                     value: BigNumber.from(deposit.amount),
-                    gasLimit: BigNumber.from(ETH_RECOMMENDED_DEPOSIT_GAS_LIMIT),
+                    gasLimit: BigNumber.from(RBTC_RECOMMENDED_DEPOSIT_GAS_LIMIT),
                     gasPrice,
                     ...deposit.ethTxOptions
                 });
@@ -650,8 +650,8 @@ export abstract class AbstractWallet {
         token: TokenLike,
         erc20ApproveThreshold: BigNumber = ERC20_APPROVE_TRESHOLD
     ): Promise<boolean> {
-        if (isTokenETH(token)) {
-            throw Error('ETH token does not need approval.');
+        if (isTokenRBTC(token)) {
+            throw Error('RBTC token does not need approval.');
         }
         const tokenAddress = this.provider.tokenSet.resolveTokenAddress(token);
         const erc20contract = new Contract(tokenAddress, IERC20_INTERFACE, this.ethSigner());

--- a/sdk/zksync.js/src/provider.ts
+++ b/sdk/zksync.js/src/provider.ts
@@ -18,7 +18,7 @@ import {
     Toggle2FARequest,
     Toggle2FAResponse
 } from './types';
-import { isTokenETH, sleep, TokenSet } from './utils';
+import { isTokenRBTC, sleep, TokenSet } from './utils';
 import {
     Governance,
     GovernanceFactory,
@@ -358,7 +358,7 @@ export class ETHProxy {
     }
 
     async resolveTokenId(token: TokenAddress): Promise<number> {
-        if (isTokenETH(token)) {
+        if (isTokenRBTC(token)) {
             return 0;
         } else {
             const tokenId = await this.governanceContract.tokenIds(token);

--- a/sdk/zksync.js/src/typechain/ZkSync.d.ts
+++ b/sdk/zksync.js/src/typechain/ZkSync.d.ts
@@ -33,7 +33,7 @@ interface ZkSyncInterface extends ethers.utils.Interface {
     "cancelOutstandingDepositsForExodusMode(uint64,bytes[])": FunctionFragment;
     "commitBlocks(tuple,tuple[])": FunctionFragment;
     "depositERC20(address,uint104,address)": FunctionFragment;
-    "depositETH(address)": FunctionFragment;
+    "depositRBTC(address)": FunctionFragment;
     "executeBlocks(tuple[])": FunctionFragment;
     "exodusMode()": FunctionFragment;
     "getNoticePeriod()": FunctionFragment;
@@ -100,7 +100,7 @@ interface ZkSyncInterface extends ethers.utils.Interface {
     functionFragment: "depositERC20",
     values: [string, BigNumberish, string]
   ): string;
-  encodeFunctionData(functionFragment: "depositETH", values: [string]): string;
+  encodeFunctionData(functionFragment: "depositRBTC", values: [string]): string;
   encodeFunctionData(
     functionFragment: "executeBlocks",
     values: [
@@ -254,7 +254,7 @@ interface ZkSyncInterface extends ethers.utils.Interface {
     functionFragment: "depositERC20",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "depositETH", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "depositRBTC", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "executeBlocks",
     data: BytesLike
@@ -476,12 +476,12 @@ export class ZkSync extends Contract {
       overrides?: Overrides
     ): Promise<ContractTransaction>;
 
-    depositETH(
+    depositRBTC(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<ContractTransaction>;
 
-    "depositETH(address)"(
+    "depositRBTC(address)"(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<ContractTransaction>;
@@ -897,12 +897,12 @@ export class ZkSync extends Contract {
     overrides?: Overrides
   ): Promise<ContractTransaction>;
 
-  depositETH(
+  depositRBTC(
     _zkSyncAddress: string,
     overrides?: PayableOverrides
   ): Promise<ContractTransaction>;
 
-  "depositETH(address)"(
+  "depositRBTC(address)"(
     _zkSyncAddress: string,
     overrides?: PayableOverrides
   ): Promise<ContractTransaction>;
@@ -1274,12 +1274,12 @@ export class ZkSync extends Contract {
       overrides?: CallOverrides
     ): Promise<void>;
 
-    depositETH(
+    depositRBTC(
       _zkSyncAddress: string,
       overrides?: CallOverrides
     ): Promise<void>;
 
-    "depositETH(address)"(
+    "depositRBTC(address)"(
       _zkSyncAddress: string,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -1689,12 +1689,12 @@ export class ZkSync extends Contract {
       overrides?: Overrides
     ): Promise<BigNumber>;
 
-    depositETH(
+    depositRBTC(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<BigNumber>;
 
-    "depositETH(address)"(
+    "depositRBTC(address)"(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<BigNumber>;
@@ -2061,12 +2061,12 @@ export class ZkSync extends Contract {
       overrides?: Overrides
     ): Promise<PopulatedTransaction>;
 
-    depositETH(
+    depositRBTC(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<PopulatedTransaction>;
 
-    "depositETH(address)"(
+    "depositRBTC(address)"(
       _zkSyncAddress: string,
       overrides?: PayableOverrides
     ): Promise<PopulatedTransaction>;

--- a/sdk/zksync.js/src/typechain/ZkSyncFactory.ts
+++ b/sdk/zksync.js/src/typechain/ZkSyncFactory.ts
@@ -484,7 +484,7 @@ const _abi = [
         type: "address",
       },
     ],
-    name: "depositETH",
+    name: "depositRBTC",
     outputs: [],
     stateMutability: "payable",
     type: "function",

--- a/sdk/zksync.js/src/types.ts
+++ b/sdk/zksync.js/src/types.ts
@@ -5,11 +5,11 @@ export type Address = string;
 // sync:-prefixed, hex encoded, hash of the account public key
 export type PubKeyHash = string;
 
-// Symbol like "ETH" or "FAU" or token contract address(zero address is implied for "ETH").
+// Symbol like "RBTC" or "FAU" or token contract address(zero address is implied for "RBTC").
 export type TokenLike = TokenSymbol | TokenAddress | number;
-// Token symbol (e.g. "ETH", "FAU", etc.)
+// Token symbol (e.g. "RBTC", "FAU", etc.)
 export type TokenSymbol = string;
-// Token address (e.g. 0xde..ad for ERC20, or 0x00.00 for "ETH")
+// Token address (e.g. 0xde..ad for ERC20, or 0x00.00 for "RBTC")
 export type TokenAddress = string;
 
 export type TotalFee = Map<TokenLike, BigNumber>;
@@ -67,7 +67,7 @@ export type EthAccountType = 'Owned' | 'CREATE2' | 'No2FA';
 
 export interface Depositing {
     balances: {
-        // Token are indexed by their symbol (e.g. "ETH")
+        // Token are indexed by their symbol (e.g. "RBTC")
         [token: string]: {
             // Sum of pending deposits for the token.
             amount: BigNumberish;
@@ -85,7 +85,7 @@ export interface AccountState {
     depositing: Depositing;
     committed: {
         balances: {
-            // Token are indexed by their symbol (e.g. "ETH")
+            // Token are indexed by their symbol (e.g. "RBTC")
             [token: string]: BigNumberish;
         };
         nfts: {
@@ -101,7 +101,7 @@ export interface AccountState {
     };
     verified: {
         balances: {
-            // Token are indexed by their symbol (e.g. "ETH")
+            // Token are indexed by their symbol (e.g. "RBTC")
             [token: string]: BigNumberish;
         };
         nfts: {
@@ -314,7 +314,7 @@ export interface ContractAddress {
 }
 
 export interface Tokens {
-    // Tokens are indexed by their symbol (e.g. "ETH")
+    // Tokens are indexed by their symbol (e.g. "RBTC")
     [token: string]: {
         address: string;
         id: number;
@@ -324,7 +324,7 @@ export interface Tokens {
 }
 
 export interface ExtendedTokens extends Tokens {
-    // Tokens are indexed by their symbol (e.g. "ETH")
+    // Tokens are indexed by their symbol (e.g. "RBTC")
     [token: string]: TokenInfo;
 }
 

--- a/sdk/zksync.js/src/utils.ts
+++ b/sdk/zksync.js/src/utils.ts
@@ -48,9 +48,9 @@ export const ERC20_APPROVE_TRESHOLD = BigNumber.from(
     '57896044618658097711785492504343953926634992332820282019728792003956564819968'
 ); // 2^255
 
-// Gas limit that is set for eth deposit by default. For default EOA accounts 60k should be enough, but we reserve
+// Gas limit that is set for rbtc deposit by default. For default EOA accounts 60k should be enough, but we reserve
 // more gas for smart-contract wallets
-export const ETH_RECOMMENDED_DEPOSIT_GAS_LIMIT = BigNumber.from('90000'); // 90k
+export const RBTC_RECOMMENDED_DEPOSIT_GAS_LIMIT = BigNumber.from('90000'); // 90k
 // For normal wallet/erc20 token 90k gas for deposit should be enough, but for some tokens this can go as high as ~200k
 // we try to be safe by default
 export const ERC20_RECOMMENDED_DEPOSIT_GAS_LIMIT = BigNumber.from('300000'); // 300k
@@ -342,8 +342,8 @@ export function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function isTokenETH(token: TokenLike): boolean {
-    return token === 'ETH' || token === constants.AddressZero;
+export function isTokenRBTC(token: TokenLike): boolean {
+    return token === 'RBTC' || token === constants.AddressZero;
 }
 
 type TokenOrId = TokenLike | number;
@@ -910,7 +910,7 @@ export async function getEthereumBalance(
     token: TokenLike
 ): Promise<BigNumber> {
     let balance: BigNumber;
-    if (isTokenETH(token)) {
+    if (isTokenRBTC(token)) {
         balance = await ethProvider.getBalance(address);
     } else {
         const erc20contract = new Contract(

--- a/sdk/zksync.js/tests/util.test.ts
+++ b/sdk/zksync.js/tests/util.test.ts
@@ -42,10 +42,10 @@ describe('Packing and unpacking', function () {
 describe('Token cache resolve', function () {
     it('Test token cache resolve', function () {
         const tokens = {
-            ETH: {
+            RBTC: {
                 address: '0x0000000000000000000000000000000000000000',
                 id: 0,
-                symbol: 'ETH',
+                symbol: 'RBTC',
                 decimals: 18
             },
             'ERC20-1': {
@@ -57,8 +57,8 @@ describe('Token cache resolve', function () {
         };
         const tokenCache = new TokenSet(tokens);
 
-        expect(tokenCache.resolveTokenId('ETH')).eq(0, 'ETH by id resolve');
-        expect(tokenCache.resolveTokenId('0x0000000000000000000000000000000000000000')).eq(0, 'ETH by addr resolve');
+        expect(tokenCache.resolveTokenId('RBTC')).eq(0, 'RBTC by id resolve');
+        expect(tokenCache.resolveTokenId('0x0000000000000000000000000000000000000000')).eq(0, 'RBTC by addr resolve');
         expect(tokenCache.resolveTokenId('ERC20-1')).eq(1, 'ERC20 by id resolve');
         expect(tokenCache.resolveTokenId('0xEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')).eq(1, 'ERC20 by addr resolve');
         expect(tokenCache.resolveTokenId('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')).eq(1, 'ERC20 by addr resolve');

--- a/sdk/zksync.js/tests/wallet.test.ts
+++ b/sdk/zksync.js/tests/wallet.test.ts
@@ -51,7 +51,7 @@ describe('Wallet with mock provider', function () {
 
         let thrown = false;
         try {
-            await wallet.getBalance('ETH', 'committed');
+            await wallet.getBalance('RBTC', 'committed');
         } catch {
             thrown = true;
         }
@@ -75,7 +75,7 @@ describe('Wallet with mock provider', function () {
 
         let thrown = false;
         try {
-            await wallet.getBalance('ETH', 'verified');
+            await wallet.getBalance('RBTC', 'verified');
         } catch {
             thrown = true;
         }


### PR DESCRIPTION
Renames all references to eth as currency to rbtc

according to [ROLLUP-184](https://rsklabs.atlassian.net/browse/ROLLUP-184)