### PR TITLE
feat(simulation): adds transfer

### DIFF
--- a/infrastructure/simulation-tool/src/index.ts
+++ b/infrastructure/simulation-tool/src/index.ts
@@ -1,9 +1,10 @@
 import { setupSimulation } from './simulations/setup';
+import { runTransferToNewSimulation } from './simulations/transferToNew';
 import config from './utils/config.utils';
 
 // FIXME: this is a workaround for the fact that the simulation tool is not yet ready to run multiple simulations in parallel
 (async function () {
-    const tasks = [];
+    const tasks = [runTransferToNewSimulation];
 
     for (const task of tasks) {
         const simulationSetup = await setupSimulation();

--- a/infrastructure/simulation-tool/src/operations/transfer.ts
+++ b/infrastructure/simulation-tool/src/operations/transfer.ts
@@ -1,0 +1,141 @@
+import { BigNumber } from 'ethers';
+import { Wallet as RollupWallet, Transaction, utils } from '@rsksmart/rif-rollup-js-sdk/';
+import config from '../utils/config.utils';
+import { getRandomBigNumber } from '../utils/number.utils';
+import { sleep } from '@rsksmart/rif-rollup-js-sdk/build/utils';
+import { Address, TransactionReceipt } from '@rsksmart/rif-rollup-js-sdk/build/types';
+import { getRandomElement } from './common';
+
+type PreparedTransfer = Omit<Parameters<RollupWallet['syncTransfer']>[number], 'amount'> & {
+    amount: BigNumber;
+    from: RollupWallet;
+};
+
+type TransferResult = {
+    opL2Receipt: TransactionReceipt;
+    verificationL2Receipt?: TransactionReceipt;
+};
+
+const prepareTransfer = (l2sender: RollupWallet, recipient: Address, amount?: BigNumber): PreparedTransfer => {
+    const [minAmount, maxAmount] = config.weiLimits.transferToNew;
+    const value = amount || utils.closestPackableTransactionAmount(getRandomBigNumber(minAmount, maxAmount));
+    console.log(`Preparing transfer of ${amount} RBTC from ${l2sender.address} to ${recipient}.`);
+    return {
+        from: l2sender,
+        to: recipient,
+        amount: value,
+        token: 'RBTC',
+        nonce: 'committed'
+    };
+};
+
+const executeTransfer = (preparedTransfer: PreparedTransfer): Promise<Transaction> => {
+    const { from, ...transferParameters } = preparedTransfer;
+    console.log(
+        `Transferring ${transferParameters.amount} RBTC from ${from.address()} to ${transferParameters.to} ...`
+    ); // commented out to reduce noise (TODO: create more sophisticated logging)
+
+    return from.syncTransfer(transferParameters);
+};
+
+const generateTransfers = (numberOfTransfers: number, users: RollupWallet[]): PreparedTransfer[] =>
+    [...Array(numberOfTransfers)].map((_, i) => {
+        process.stdout.write(`${i},`);
+
+        return prepareTransfer(getRandomElement(users), getRandomElement(users).address());
+    });
+
+const generateTransfersToNew = (numberOfTransfers: number, users: RollupWallet[]): PreparedTransfer[] => {
+    const [funder, ...receipts] = users;
+
+    return [...Array(numberOfTransfers)].map((_, i) => {
+        process.stdout.write(`${i},`);
+
+        return prepareTransfer(funder, getRandomElement(receipts).address());
+    });
+};
+
+const executeTransfers = async (
+    preparedTransfers: PreparedTransfer[],
+    delay: number
+): Promise<Promise<Transaction>[]> => {
+    console.log('Executing transfers: ');
+    let firstNonce = await preparedTransfers[0].from.getNonce('committed');
+    const executedTx: Promise<Transaction>[] = [];
+    const shouldSleep = (i: number) => preparedTransfers.length - 1 > i;
+    for (let [i, transfer] of preparedTransfers.entries()) {
+        process.stdout.write(`${i},`);
+        executedTx.push(executeTransfer({ ...transfer, nonce: firstNonce + i }));
+        shouldSleep(i) && (await sleep(delay));
+    }
+
+    return executedTx;
+};
+
+const resolveTransaction = async (executedTx: Transaction): Promise<TransferResult> => {
+    // TODO: move to some L2 utils (along with "resolveRootstockOperation")
+    const opL2Receipt = await executedTx.awaitReceipt();
+    console.log(
+        `Transaction with hash #${executedTx.txHash} ${
+            opL2Receipt.success ? 'added' : 'failed with: ' + opL2Receipt.failReason
+        } in block #${opL2Receipt.block.blockNumber}.`
+    );
+    console.log('Waiting for block verification ...');
+    const verificationL2Receipt = await executedTx.awaitVerifyReceipt();
+    console.log(
+        `Verification of block #${verificationL2Receipt.block.blockNumber} ${
+            verificationL2Receipt.success ? 'successful' : 'failed with: ' + verificationL2Receipt.failReason
+        }.`
+    );
+
+    return {
+        opL2Receipt,
+        verificationL2Receipt
+    };
+};
+
+const resolveTransactions = async (executedTx: Transaction[], blocking?: boolean) => {
+    // TODO: move to some L2 utils (along with "resolveRootstockOperation")
+    console.log('Resolving transactions: ');
+    if (!blocking) {
+        return Promise.all(executedTx.map(resolveTransaction));
+    }
+
+    let receipts: TransferResult[] = [];
+    for (const [i, tx] of executedTx.entries()) {
+        const opL2Receipt = await tx.awaitReceipt();
+        console.log(
+            `Transaction #${i} with hash #${tx.txHash} ${
+                opL2Receipt.success ? 'added' : 'failed with: ' + opL2Receipt.failReason
+            } in block #${opL2Receipt.block.blockNumber}.`
+        );
+        console.log('Waiting for block verification ...');
+        const verificationL2Receipt = await tx.awaitVerifyReceipt();
+        console.log(
+            `Verification of block #${verificationL2Receipt.block.blockNumber} ${
+                verificationL2Receipt.success ? 'successful' : 'failed with: ' + verificationL2Receipt.failReason
+            }.`
+        );
+        receipts = [
+            ...receipts,
+            {
+                opL2Receipt,
+                verificationL2Receipt
+            }
+        ];
+    }
+
+    return receipts;
+};
+
+export type { PreparedTransfer, TransferResult };
+
+export {
+    prepareTransfer,
+    executeTransfer,
+    generateTransfers,
+    generateTransfersToNew,
+    executeTransfers,
+    resolveTransactions,
+    resolveTransaction as resolveTransfer
+};

--- a/infrastructure/simulation-tool/src/simulations/transferToNew.ts
+++ b/infrastructure/simulation-tool/src/simulations/transferToNew.ts
@@ -1,0 +1,58 @@
+import { Transaction, Wallet } from '@rsksmart/rif-rollup-js-sdk';
+import { BigNumber, constants } from 'ethers';
+import { ensureRollupFunds } from '../operations/common';
+import {
+    PreparedTransfer,
+    executeTransfers,
+    generateTransfersToNew,
+    resolveTransactions
+} from '../operations/transfer';
+import config from '../utils/config.utils';
+import { generateWallets } from '../utils/wallet.utils';
+import { SimulationConfiguration } from './setup';
+
+const runSimulation = async ({ walletGenerator, txCount, txDelay, funderL2Wallet }: SimulationConfiguration) => {
+    const { numberOfAccounts } = config;
+    // Create users
+    console.log('Creating transfer users from HD wallet ...');
+    let users: Wallet[] = [];
+    let done = false;
+
+    while (users.length < numberOfAccounts - 1 && !done) {
+        const { value: account, ...result } = await walletGenerator.next();
+        done = result.done;
+
+        const isActive = await account.isSigningKeySet();
+        if (!isActive) {
+            users.push(account);
+        }
+    }
+    await generateWallets(numberOfAccounts - 1, walletGenerator);
+
+    console.log(`Created ${users.length} users.`);
+
+    // Create transactions
+    console.log(`Creating ${txCount} transfers ...`);
+
+    const preparedTransfers: PreparedTransfer[] = generateTransfersToNew(txCount, [funderL2Wallet, ...users]);
+    console.log(`Created ${preparedTransfers.length} transfers`);
+
+    // Verify transactions
+    const totalTransferAmount = preparedTransfers.reduce((accumulator: BigNumber, { amount }: PreparedTransfer) => {
+        accumulator.add(amount);
+
+        return accumulator;
+    }, constants.Zero);
+
+    await ensureRollupFunds(totalTransferAmount, funderL2Wallet);
+
+    // Execute transactions
+    const executedTx: Transaction[] = await Promise.all(
+        (await executeTransfers(preparedTransfers, txDelay)).map((tx) => tx)
+    );
+
+    // List execution results
+    await resolveTransactions(executedTx, true);
+};
+
+export { runSimulation as runTransferToNewSimulation };

--- a/infrastructure/simulation-tool/test/operations/transfer.test.ts
+++ b/infrastructure/simulation-tool/test/operations/transfer.test.ts
@@ -1,0 +1,159 @@
+import { Wallet as RollupWallet, Transaction } from '@rsksmart/rif-rollup-js-sdk';
+import { utils } from '@rsksmart/rif-rollup-js-sdk/';
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { executeTransfer, executeTransfers, generateTransfers, prepareTransfer } from '../../src/operations/transfer';
+import config from '../../src/utils/config.utils';
+import { constants } from 'ethers';
+
+use(sinonChai);
+
+afterEach(() => {
+    sinon.restore();
+});
+
+describe('prepareTransfer', () => {
+    it('should return transfer parameters with amount between min and max', () => {
+        const sender = sinon.createStubInstance(RollupWallet);
+        const recipient = constants.AddressZero;
+        const transfer = prepareTransfer(sender, recipient);
+        const [minAmount, maxAmount] = config.weiLimits.transferToNew;
+
+        expect(transfer.amount.gte(minAmount)).to.be.true;
+        expect(transfer.amount.lt(maxAmount)).to.be.true;
+    });
+
+    it('should return a transfer with token address set to zero', () => {
+        const sender = sinon.createStubInstance(RollupWallet);
+        const recipient = constants.AddressZero;
+        const transfer = prepareTransfer(sender, recipient);
+
+        expect(transfer.token).to.eq('RBTC');
+    });
+
+    it('should return a transfer with nonce set to committed', () => {
+        const sender = sinon.createStubInstance(RollupWallet);
+        const recipient = constants.AddressZero;
+        const transfer = prepareTransfer(sender, recipient);
+
+        expect(transfer.nonce).to.eq('committed');
+    });
+});
+
+describe('executeTransfer', () => {
+    it('should execute transfer', async () => {
+        const sender = sinon.createStubInstance(RollupWallet);
+        sender.syncTransfer.callsFake(() => Promise.resolve(sinon.createStubInstance(Transaction)));
+        const recipient = constants.AddressZero;
+        const transfer = prepareTransfer(sender, recipient);
+        const expectedParameters = { ...transfer };
+        delete expectedParameters.from;
+        await executeTransfer(transfer);
+
+        expect(sender.syncTransfer).to.have.been.calledOnceWith(expectedParameters);
+    });
+
+    it('should return Rollup transaction', async () => {
+        const sender = sinon.createStubInstance(RollupWallet);
+        sender.syncTransfer.callsFake(() => Promise.resolve(sinon.createStubInstance(Transaction)));
+        const recipient = constants.AddressZero;
+        const transfer = prepareTransfer(sender, recipient);
+        const transferOperation = await executeTransfer(transfer);
+
+        expect(transferOperation).to.be.instanceOf(Transaction);
+    });
+});
+
+describe('generateTransfers', () => {
+    it('should generate expected number of transfers', () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        const users = [funderL2Wallet, ...Array(numberOfTransfers)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+
+        expect(transfers.length).to.eq(numberOfTransfers);
+    });
+
+    it('should generate transfers with funder as sender', () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        const users = [funderL2Wallet, ...Array(numberOfTransfers)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+
+        transfers.forEach((transfer) => {
+            expect(transfer.from).to.eq(funderL2Wallet);
+        });
+    });
+
+    it('should generate transfers with for users', () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        const users = [funderL2Wallet, ...Array(numberOfTransfers)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+        const expectedRecipients = users.map((receipient) => receipient.address);
+
+        transfers.forEach((transfer) => {
+            expect(expectedRecipients).to.include(transfer.to);
+        });
+    });
+});
+
+describe('executeTransfers', () => {
+    it('should execute all transfers', async () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        funderL2Wallet.syncTransfer.resolves(sinon.createStubInstance(Transaction));
+        const users = [...Array(5)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+        const delay = 0;
+        sinon.stub(utils, 'sleep').callsFake(() => Promise.resolve());
+        const executedTransfers = await executeTransfers(transfers, delay);
+
+        expect(executedTransfers.length).to.eq(numberOfTransfers);
+    });
+
+    it('should return executed transfers', async () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        funderL2Wallet.syncTransfer.resolves(sinon.createStubInstance(Transaction));
+        const users = [...Array(5)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+        const delay = 0;
+        sinon.stub(utils, 'sleep').callsFake(() => Promise.resolve());
+        const executedTransfers = await executeTransfers(transfers, delay);
+
+        for (const executedTransfer of executedTransfers) {
+            expect(await executedTransfer).to.be.instanceOf(Transaction);
+        }
+    });
+
+    it('should delay between transfers', async () => {
+        const numberOfTransfers = 10;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        funderL2Wallet.syncTransfer.resolves(sinon.createStubInstance(Transaction));
+        const users = [...Array(5)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+        const delay = 100;
+        const sleepStub = sinon.stub(utils, 'sleep').callsFake(() => Promise.resolve());
+        await executeTransfers(transfers, delay);
+
+        expect(sleepStub).to.have.callCount(numberOfTransfers - 1);
+    });
+
+    it('should executed correct number of transfers per second', async function () {
+        const expectedTPS = 3;
+        const totalSimTime = 3;
+        const numberOfTransfers = expectedTPS * totalSimTime;
+        const funderL2Wallet = sinon.createStubInstance(RollupWallet);
+        const syncTransferSpy = funderL2Wallet.syncTransfer;
+        funderL2Wallet.syncTransfer.resolves(sinon.createStubInstance(Transaction));
+        const users = [...Array(5)].map(() => sinon.createStubInstance(RollupWallet));
+        const transfers = generateTransfers(numberOfTransfers, users);
+        const delay = 1000 / expectedTPS;
+        this.timeout(totalSimTime * 1000);
+        await executeTransfers(transfers, delay);
+
+        expect(syncTransferSpy.callCount / totalSimTime).to.eq(expectedTPS);
+    });
+});


### PR DESCRIPTION
Adds transfer-to-new simulation capability.

This PR exists mainly as a result of splitting https://github.com/rsksmart/rif-rollup/pull/85, as it was getting too large.
This one is the 2nd out of 3 parts: [
#89,
this,
#91,
]

Ref: https://rsklabs.atlassian.net/browse/ROLLUP-244

Since this is part of a bigger WIP, I suggest keeping the console logs, including debugging 🦆 ones.


> **Warning**
> once #89 is merged, change the target branch to main