### PR TITLE
fix: modify some missing files including USDRIF

### DIFF
--- a/etc/env/mainnet/fee_ticker.toml
+++ b/etc/env/mainnet/fee_ticker.toml
@@ -15,7 +15,7 @@ liquidity_volume=100
 available_liquidity_seconds=720
 # List of the tokens that are unconditionally acceptable for paying fee in. <env_address>
 # Pre-configured RBTC, RIF, RDOC in that order
-unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x2acc95758f8b5f583470ba265eb685a8f45fc9d5","0x2d919f19D4892381d58EdEbEcA66D5642ceF1A1F"]  
+unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x2acc95758f8b5f583470ba265eb685a8f45fc9d5","0x2d919f19D4892381d58EdEbEcA66D5642ceF1A1F", "0x3A15461d8AE0f0Fb5fA2629e9dA7D66A794a6E37"]
 token_market_update_time=120
 # Number of tickers for load balancing.
 number_of_ticker_actors=5

--- a/etc/env/qa/fee_ticker.toml
+++ b/etc/env/qa/fee_ticker.toml
@@ -15,7 +15,7 @@ liquidity_volume=100
 available_liquidity_seconds=720
 # List of the tokens that are unconditionally acceptable for paying fee in. <env_address>
 # Pre-configured RBTC, RIF, RDOC in that order
-unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE", "0xC3De9f38581F83e281F260D0ddBAac0E102Ff9F8"]
+unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE", "0xC3De9f38581F83e281F260D0ddBAac0E102Ff9F8", "0x8dbf326e12a9ff37ed6ddf75ada548c2640a6482"]
 token_market_update_time=120
 # Number of tickers for load balancing.
 number_of_ticker_actors=5

--- a/etc/env/testnet/fee_ticker.toml
+++ b/etc/env/testnet/fee_ticker.toml
@@ -15,7 +15,7 @@ liquidity_volume=100
 available_liquidity_seconds=720
 # List of the tokens that are unconditionally acceptable for paying fee in. <env_address>
 # Pre-configured RBTC, RIF, RDOC in that order
-unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE", "0xC3De9f38581F83e281F260D0ddBAac0E102Ff9F8"]
+unconditionally_valid_tokens=["0x0000000000000000000000000000000000000000", "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE", "0xC3De9f38581F83e281F260D0ddBAac0E102Ff9F8", "0x8dbF326E12a9fF37ED6ddf75adA548c2640a6482"]
 token_market_update_time=120
 # Number of tickers for load balancing.
 number_of_ticker_actors=5

--- a/etc/token-lists/testnet.json
+++ b/etc/token-lists/testnet.json
@@ -10,6 +10,12 @@
       "decimals": 18,
       "symbol": "rDOC",
       "name": "rDOC"
+    },
+    {
+      "address": "0x8dbf326e12a9ff37ed6ddf75ada548c2640a6482",
+      "decimals": 18,
+      "symbol": "USDRIF",
+      "name": "RIF US Dollar"
     }
   ]
   

--- a/etc/tokens/mainnet.json
+++ b/etc/tokens/mainnet.json
@@ -10,5 +10,11 @@
         "decimals": 18,
         "symbol": "RDOC",
         "name": "RIF Dollar on Chain"
+    },
+    {
+        "address": "0x3A15461d8AE0f0Fb5fA2629e9dA7D66A794a6E37",
+        "decimals": 18,
+        "symbol": "USDRIF",
+        "name": "RIF US Dollar"
     }
 ]

--- a/etc/tokens/testnet.json
+++ b/etc/tokens/testnet.json
@@ -10,5 +10,11 @@
         "decimals": 18,
         "symbol": "rDOC",
         "name": "RIF Dollar on Chain"
+    },
+    {
+        "address": "0x8dbf326e12a9ff37ed6ddf75ada548c2640a6482",
+        "decimals": 18,
+        "symbol": "USDRIF",
+        "name": "RIF US Dollar"
     }
 ]


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

## What

Properly handle USDRIF in all environments

## Why

Previous PR (see refs) was taking care just about localhost

## Refs

https://github.com/rsksmart/rif-rollup/pull/102