### PR TITLE
fix: fix coinmarketcap client tests

### DIFF
--- a/core/bin/zksync_api/src/bin/providers/dev_price_provider.rs
+++ b/core/bin/zksync_api/src/bin/providers/dev_price_provider.rs
@@ -5,7 +5,7 @@
 
 use actix_web::{web, HttpRequest, HttpResponse, Result};
 use bigdecimal::BigDecimal;
-use chrono::{Utc, SecondsFormat};
+use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{collections::HashMap, fs::read_to_string, path::Path};
@@ -88,7 +88,6 @@ async fn handle_coinmarketcap_token_price_query(
     vlog::info!("1.0 {} = {} USD", query.symbol, price);
     Ok(HttpResponse::Ok().json(resp))
 }
-
 
 #[derive(Debug, Deserialize)]
 struct Token {
@@ -201,7 +200,10 @@ pub fn create_price_service(sloppy_mode: bool) -> actix_web::Scope {
                 "/cryptocurrency/quotes/latest",
                 web::get().to(handle_coinmarketcap_token_price_query),
             )
-            .route(format!("{}/coins/list", API_PATH).as_str(), web::get().to(handle_coingecko_token_list))
+            .route(
+                format!("{}/coins/list", API_PATH).as_str(),
+                web::get().to(handle_coingecko_token_list),
+            )
             .route(
                 format!("{}/coins/{{coin_id}}/market_chart", API_PATH).as_str(),
                 web::get().to(handle_coingecko_token_price_query),

--- a/core/bin/zksync_api/src/bin/providers/dev_price_provider.rs
+++ b/core/bin/zksync_api/src/bin/providers/dev_price_provider.rs
@@ -5,7 +5,7 @@
 
 use actix_web::{web, HttpRequest, HttpResponse, Result};
 use bigdecimal::BigDecimal;
-use chrono::Utc;
+use chrono::{Utc, SecondsFormat};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{collections::HashMap, fs::read_to_string, path::Path};
@@ -49,6 +49,46 @@ macro_rules! make_sloppy {
         }
     }};
 }
+
+async fn handle_coinmarketcap_token_price_query(
+    query: web::Query<CoinMarketCapTokenQuery>,
+    _data: web::Data<Vec<TokenData>>,
+) -> Result<HttpResponse> {
+    let symbol = query.symbol.clone();
+    let base_price = match symbol.as_str() {
+        "RBTC" => BigDecimal::from(1800),
+        "wBTC" => BigDecimal::from(9000),
+        // Even though these tokens have their base price equal to
+        // the default one, we still keep them here so that in the future it would
+        // be easier to change the default price without affecting the important tokens
+        "DAI" => BigDecimal::from(1),
+        "tGLM" => BigDecimal::from(1),
+        "GLM" => BigDecimal::from(1),
+
+        "RIF" => BigDecimal::try_from(0.053533).unwrap(),
+        _ => BigDecimal::from(1),
+    };
+    let random_multiplier = thread_rng().gen_range(0.9, 1.1);
+
+    let price = base_price * BigDecimal::try_from(random_multiplier).unwrap();
+
+    let last_updated = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let resp = json!({
+        "data": {
+            symbol: {
+                "quote": {
+                    "USD": {
+                        "price": price.to_string(),
+                        "last_updated": last_updated
+                    }
+                }
+            }
+        }
+    });
+    vlog::info!("1.0 {} = {} USD", query.symbol, price);
+    Ok(HttpResponse::Ok().json(resp))
+}
+
 
 #[derive(Debug, Deserialize)]
 struct Token {
@@ -140,22 +180,30 @@ pub fn create_price_service(sloppy_mode: bool) -> actix_web::Scope {
         .chain(testnet_tokens.into_iter())
         .collect();
     if sloppy_mode {
-        web::scope(API_PATH)
+        web::scope("")
             .app_data(web::Data::new(data))
             .route(
-                "/coins/list",
+                "/cryptocurrency/quotes/latest",
+                web::get().to(make_sloppy!(handle_coinmarketcap_token_price_query)),
+            )
+            .route(
+                format!("{}/coins/list", API_PATH).as_str(),
                 web::get().to(make_sloppy!(handle_coingecko_token_list)),
             )
             .route(
-                "/coins/{coin_id}/market_chart",
+                format!("{}/coins/{{coin_id}}/market_chart", API_PATH).as_str(),
                 web::get().to(make_sloppy!(handle_coingecko_token_price_query)),
             )
     } else {
-        web::scope(API_PATH)
+        web::scope("")
             .app_data(web::Data::new(data))
-            .route("/coins/list", web::get().to(handle_coingecko_token_list))
             .route(
-                "/coins/{coin_id}/market_chart",
+                "/cryptocurrency/quotes/latest",
+                web::get().to(handle_coinmarketcap_token_price_query),
+            )
+            .route(format!("{}/coins/list", API_PATH).as_str(), web::get().to(handle_coingecko_token_list))
+            .route(
+                format!("{}/coins/{{coin_id}}/market_chart", API_PATH).as_str(),
                 web::get().to(handle_coingecko_token_price_query),
             )
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
   dev-ticker:
     image: "rsksmart/rollup-dev-ticker:1.0.0-beta"
     env_file:
+      - ./etc/env/${ZKSYNC_ENV-dev}.env
       - ./etc/env/${ENV_OVERRIDE-deploy}.env
     ports:
       - "9876:9876"

--- a/docker/environment/Dockerfile
+++ b/docker/environment/Dockerfile
@@ -26,6 +26,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 RUN rustup install 1.69.0
+RUN rustup override set 1.69.0
 RUN cargo install diesel_cli  --version=1.4.0 --no-default-features --features postgres
 RUN cargo install --version=0.5.6 sqlx-cli
 RUN cargo install wasm-pack --git https://github.com/d3lm/wasm-pack --rev 713868b204f151acd1989c3f29ff9d3bc944c306

--- a/infrastructure/zk/src/test/test.ts
+++ b/infrastructure/zk/src/test/test.ts
@@ -76,7 +76,7 @@ async function rustCryptoTests() {
 }
 
 export async function serverRust() {
-    await utils.spawn(`${CARGO_FLAGS} cargo test --release`);
+    await utils.spawn(`${CARGO_FLAGS} cargo test --release -- --test-threads=1`);
     await db(true);
     await rustApi(true);
     await prover();


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

## What

- restore the coinmarketcap handler in dev_price_ticker

## Why

- it could be used for dev purposes
- it's used to test the coinmarketcap client

